### PR TITLE
Let's add a merge with a combiner function and an OrderedDict result!

### DIFF
--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -429,3 +429,12 @@ function merge(d::OrderedDict, others::AbstractDict...)
     end
     merge!(OrderedDict{K,V}(), d, others...)
 end
+
+function merge(combine::Function, d::OrderedDict, others::AbstractDict...)
+    K, V = keytype(d), valtype(d)
+    for other in others
+        K = promote_type(K, keytype(other))
+        V = promote_type(V, valtype(other))
+    end
+    merge!(combine, OrderedDict{K,V}(), d, others...)
+end

--- a/test/test_ordered_dict.jl
+++ b/test/test_ordered_dict.jl
@@ -406,4 +406,9 @@ using OrderedCollections, Test
         @test collect(values(sdv)) == collect('q':'z')
     end
 
+    @testset "Pull Request #11" begin
+        @test merge!(+, OrderedDict(:a=>1, :b=>2), OrderedDict(:b=>7, :c=>4)) == OrderedDict(:a=>1, :b=>9, :c=>4)
+        @test merge!(+, OrderedDict(:a=>1, :b=>2), Dict(:b=>7, :c=>4)) isa OrderedDict
+    end
+
 end # @testset OrderedDict

--- a/test/test_ordered_dict.jl
+++ b/test/test_ordered_dict.jl
@@ -406,9 +406,9 @@ using OrderedCollections, Test
         @test collect(values(sdv)) == collect('q':'z')
     end
 
-    @testset "Pull Request #11" begin
-        @test merge!(+, OrderedDict(:a=>1, :b=>2), OrderedDict(:b=>7, :c=>4)) == OrderedDict(:a=>1, :b=>9, :c=>4)
-        @test merge!(+, OrderedDict(:a=>1, :b=>2), Dict(:b=>7, :c=>4)) isa OrderedDict
+    @testset "Test that OrderedDict merge with combiner returns type OrderedDict" begin
+        @test merge(+, OrderedDict(:a=>1, :b=>2), OrderedDict(:b=>7, :c=>4)) == OrderedDict(:a=>1, :b=>9, :c=>4)
+        @test merge(+, OrderedDict(:a=>1, :b=>2), Dict(:b=>7, :c=>4)) isa OrderedDict
     end
 
 end # @testset OrderedDict


### PR DESCRIPTION
This function just overrides the default base dict result type (similar to the functionality of merge without a combiner function).

In the future, this function could also be of a thin wrapper around OrderedDict to make a OrderedMultiDict type.

I have found OrderedCollections to be tremendously useful for producing deterministic generated function results, so thanks!