### PR TITLE
Add LittleDict

### DIFF
--- a/src/OrderedCollections.jl
+++ b/src/OrderedCollections.jl
@@ -17,10 +17,12 @@ module OrderedCollections
                  valtype, lastindex, nextind,
                  copymutable, emptymutable
 
-    export OrderedDict, OrderedSet
+    export OrderedDict, OrderedSet, LittleDict
+    export freeze
 
     include("dict_support.jl")
     include("ordered_dict.jl")
+    include("little_dict.jl")
     include("ordered_set.jl")
     include("dict_sorting.jl")
 

--- a/src/dict_sorting.jl
+++ b/src/dict_sorting.jl
@@ -20,15 +20,12 @@ end
 sort(d::OrderedDict; args...) = sort!(copy(d); args...)
 sort(d::Dict; args...) = sort!(OrderedDict(d); args...)
 
-function sort!(d::LittleDict; byvalue::Bool=false, args...)
+function sort(d::LittleDict; byvalue::Bool=false, args...)
     if byvalue
         p = sortperm(d.vals; args...)
     else
         p = sortperm(d.keys; args...)
     end
-    d.keys = d.keys[p]
-    d.vals = d.vals[p]
-    return d
+    return LittleDict(d.keys[p], d.vals[p])
 end
 
-sort(d::LittleDict; args) = sort!(copy(d,args))

--- a/src/dict_sorting.jl
+++ b/src/dict_sorting.jl
@@ -19,3 +19,16 @@ end
 
 sort(d::OrderedDict; args...) = sort!(copy(d); args...)
 sort(d::Dict; args...) = sort!(OrderedDict(d); args...)
+
+function sort!(d::LittleDict; byvalue::Bool=false, args...)
+    if byvalue
+        p = sortperm(d.vals; args...)
+    else
+        p = sortperm(d.keys; args...)
+    end
+    d.keys = d.keys[p]
+    d.vals = d.vals[p]
+    return d
+end
+
+sort(d::LittleDict; args) = sort!(copy(d,args))

--- a/src/little_dict.jl
+++ b/src/little_dict.jl
@@ -105,7 +105,7 @@ end
 struct NotFoundSentinel end  # Struct to mark not not found
 function Base.get(dd::LittleDict, key, default)
     @assert length(dd.keys) == length(dd.vals)
-    @simd for ii in 1:length(dd.keys)
+    for ii in 1:length(dd.keys)
         cand = @inbounds dd.keys[ii]
         isequal(cand, key) && return @inbounds(dd.vals[ii])
     end
@@ -193,7 +193,7 @@ function Base.setindex!(dd::LittleDict, value, key)
     # setindex! it has huge code (26%), this does mean that if someone has messed
     # with the fields of the LittleDict directly, then the @inbounds could be invalid
     #@assert length(dd.keys) == length(dd.vals)
-    for ii in 1:length(dd.keys)
+    @simd for ii in 1:length(dd.keys)
         cand = @inbounds dd.keys[ii]
         if isequal(cand, key)
             @inbounds(dd.vals[ii] = value)

--- a/src/little_dict.jl
+++ b/src/little_dict.jl
@@ -119,7 +119,14 @@ function Base.setindex!(dd::LittleDict, value, key)
     end
     # Not found, add to the end
     push!(dd.keys, key)
-    push!(dd.vals, value)
+    try
+        push!(dd.vals, value)
+    catch
+        # if we sucessfully added  a key, but failed to add a value
+        # then we need to remove the key so the little dict remains with constistant state
+        pop!(dd.keys)
+        rethrow()
+    end
     return value
 end
 

--- a/src/little_dict.jl
+++ b/src/little_dict.jl
@@ -25,9 +25,16 @@ struct LittleDict{K,V,KS<:StoreType,VS<:StoreType} <: AbstractDict{K, V}
     vals::VS
 end
 
-function LittleDict(ks::KS, vs::VS) where {KS<:StoreType,VS<:StoreType}
-    return LittleDict{eltype(KS), eltype(VS), KS, VS}(ks, vs)
+function LittleDict{K,V}(ks::KS, vs::VS) where {K,V, KS<:StoreType,VS<:StoreType}
+    K<:eltype(KS) || ArgumentError("Invalid store type $KS, for key type $K")
+    V<:eltype(VS) || ArgumentError("Invalid store type $VS, for value type $K")
+    return LittleDict{K, V, KS, VS}(ks, vs)
 end
+
+function LittleDict(ks::KS, vs::VS) where {KS<:StoreType,VS<:StoreType}
+    return LittleDict{eltype(KS), eltype(VS)}(ks, vs)
+end
+
 
 # Other iterators should be copyed to a Vector
 LittleDict(ks, vs) = LittleDict(collect(ks), collect(vs))

--- a/src/little_dict.jl
+++ b/src/little_dict.jl
@@ -23,6 +23,16 @@ as well as on how many hash collisions occur etc.
 struct LittleDict{K,V,KS<:StoreType,VS<:StoreType} <: AbstractDict{K, V}
     keys::KS
     vals::VS
+
+    function LittleDict{K,V,KS,VS}(keys,vals) where {K,V,KS,VS}
+        if length(keys) != length(vals)
+            throw(ArgumentError(
+                "Number of keys ($(length(keys))) differs from " *
+                "number of values ($(length(vals))"
+            ))
+        end
+        return new(keys,vals)
+    end
 end
 
 function LittleDict{K,V}(ks::KS, vs::VS) where {K,V, KS<:StoreType,VS<:StoreType}

--- a/src/little_dict.jl
+++ b/src/little_dict.jl
@@ -25,9 +25,12 @@ struct LittleDict{K,V,KS<:StoreType,VS<:StoreType} <: AbstractDict{K, V}
     vals::VS
 end
 
-function LittleDict(ks::KS, vs::VS) where {KS,VS}
+function LittleDict(ks::KS, vs::VS) where {KS<:StoreType,VS<:StoreType}
     return LittleDict{eltype(KS), eltype(VS), KS, VS}(ks, vs)
 end
+
+# Other iterators should be copyed to a Vector
+LittleDict(ks, vs) = LittleDict(collect(ks), collect(vs))
 
 
 function LittleDict{K,V}(itr) where {K,V}
@@ -70,9 +73,8 @@ kvtype(::Type{Tuple{K,<:Any}}) where {K} = (K,Any)
     freeze(dd::AbstractDict)
 Render an dictionary immutable by converting it to a `Tuple` backed
 `LittleDict`.
-This will make it faster if it is small enough.
-In particular the `Tuple` backed `LittleDict` is faster than the
-`Vector` backed `LittleDict`.
+The `Tuple` backed `LittleDict` is faster than the `Vector` backed `LittleDict`,
+particularly when the keys are all concretely typed.
 """
 function freeze(dd::AbstractDict)
     ks = Tuple(keys(dd))

--- a/src/little_dict.jl
+++ b/src/little_dict.jl
@@ -193,7 +193,7 @@ function Base.setindex!(dd::LittleDict, value, key)
     # setindex! it has huge code (26%), this does mean that if someone has messed
     # with the fields of the LittleDict directly, then the @inbounds could be invalid
     #@assert length(dd.keys) == length(dd.vals)
-    @simd for ii in 1:length(dd.keys)
+    for ii in 1:length(dd.keys)
         cand = @inbounds dd.keys[ii]
         if isequal(cand, key)
             @inbounds(dd.vals[ii] = value)
@@ -212,7 +212,7 @@ end
 function Base.pop!(dd::LittleDict, key)
     @assert length(dd.keys) == length(dd.vals)
     
-    @simd for ii in 1:length(dd.keys)
+    for ii in 1:length(dd.keys)
         cand = @inbounds dd.keys[ii]
         if isequal(cand, key)
             deleteat!(dd.keys, ii)

--- a/src/little_dict.jl
+++ b/src/little_dict.jl
@@ -235,7 +235,9 @@ Base.empty!(dd::LittleDict) = (empty!(dd.keys); empty!(dd.vals); dd)
 function get!(default::Base.Callable, dd::LittleDict, key)
     got = get(dd, key, NotFoundSentinel())
     if got isa NotFoundSentinel  # not found
-        return add_new!(dd, key, default())
+        val = default()
+        add_new!(dd, key, val)
+        return val
     else
         return got
     end

--- a/src/little_dict.jl
+++ b/src/little_dict.jl
@@ -1,0 +1,89 @@
+"""
+    LittleDict(keys, vals)<:AbstractDict
+
+A ordered dictionary type for small numbers of keys.
+Rather than using `hash` or some other sophisicated measure
+to store the vals in a clever arrangement,
+it just keeps everything in a pair of lists.
+
+While theoretically this has expected time complexity _O(n)_,
+vs the hash-based `OrderDict`/`Dict`'s expected time complexity _O(1)_,
+and the search-tree-based `SortedDict`'s expected time complcity _O(log(n))_.
+In practice it is really fast, because it is cache & SIMD friendly.
+
+It is reasonable to expect it to outperform an `OrderedDict`,
+with up to around 30 elements in general;
+or with up to around 50 elements if using a `LittleDict` backed by `Tuples`
+(see [`freeze`](@ref))
+However, this depends on exactly how long `isequal` and `hash` take,
+as well as on how many hash collisions occur etc.
+"""
+struct LittleDict{K,V,KS,VS} <: AbstractDict{K, V}
+    keys::KS
+    vals::VS
+end
+
+function LittleDict(ks::KS, vs::VS) where {KS,VS}
+    return LittleDict{eltype(KS), eltype(VS), KS, VS}(ks, vs)
+end
+
+
+function LittleDict{K,V}(itr) where {K,V}
+    ks = K[]
+    vs = V[]
+    for (k, v) in itr
+        push!(ks, k)
+        push!(vs, v)
+    end
+    return LittleDict(ks, vs)
+end
+
+LittleDict{K,V}() where {K,V} = LittleDict{K,V}(tuple())
+LittleDict() = LittleDict{Any, Any}()
+LittleDict(itr::T) where T = LittleDict{kvtype(eltype(T))...}(itr)
+
+kvtype(::Any) = (Any, Any)
+kvtype(::Type{<:Pair{K,V}}) where {K,V} = (K,V)
+kvtype(::Type{<:Tuple{K,V}}) where {K,V} = (K,V)
+
+
+Base.length(dd::LittleDict) = length(dd.keys)
+Base.sizehint!(dd::LittleDict) = (sizehint!(dd.ks); sizehint!(dd.vs))
+
+function Base.getindex(dd::LittleDict, key)
+    @assert length(dd.keys) == length(dd.vals)
+    @simd for ii in 1:length(dd.keys)
+        cand = @inbounds dd.keys[ii]
+        isequal(cand, key) && return @inbounds(dd.vals[ii])
+    end
+    throw(KeyError(key))
+end
+
+function Base.setindex!(dd::LittleDict, value, key)
+    @assert length(dd.keys) == length(dd.vals)
+    @simd for ii in 1:length(dd.keys)
+        cand = @inbounds dd.keys[ii]
+        isequal(cand, key) && return @inbounds(dd.vals[ii] = value)
+    end
+    # Not found, add to the end
+    push!(dd.keys, key)
+    push!(dd.vals, value)
+    return value
+end
+
+Base.iterate(dd::LittleDict, args...) = iterate(zip(dd.keys, dd.vals), args...)
+
+
+"""
+    freeze(dd::AbstractDict)
+Render an dictionary immutable by converting it to a `Tuple` backed
+`LittleDict`.
+This will make it faster if it is small enough.
+In particular the `Tuple` backed `LittleDict` is faster than the 
+`Vector` backed `LittleDict`.
+"""
+function freeze(dd::AbstractDict)
+    ks = Tuple(keys(dd))
+    vs = Tuple(values(dd))
+    return LittleDict(ks, vs)
+end

--- a/src/little_dict.jl
+++ b/src/little_dict.jl
@@ -49,7 +49,6 @@ function LittleDict{K,V}(itr) where {K,V}
     return LittleDict(ks, vs)
 end
 
-#LittleDict() = LittleDict{Any, Any}()
 LittleDict{K,V}(itr...) where {K,V} = LittleDict{K,V}(itr)
 LittleDict(itr...) = LittleDict(itr)
 LittleDict(itr::T) where T = LittleDict{kvtype(eltype(T))...}(itr)

--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -421,20 +421,21 @@ function iterate(t::OrderedDict, i)
     return (Pair(t.keys[i],t.vals[i]), i+1)
 end
 
-function merge(d::OrderedDict, others::AbstractDict...)
+function _merge_kvtypes(d, others...)
     K, V = keytype(d), valtype(d)
     for other in others
         K = promote_type(K, keytype(other))
         V = promote_type(V, valtype(other))
     end
+    return (K,V)
+end
+
+function merge(d::OrderedDict, others::AbstractDict...)
+    K,V = _merge_kvtypes(d, others...)
     merge!(OrderedDict{K,V}(), d, others...)
 end
 
 function merge(combine::Function, d::OrderedDict, others::AbstractDict...)
-    K, V = keytype(d), valtype(d)
-    for other in others
-        K = promote_type(K, keytype(other))
-        V = promote_type(V, valtype(other))
-    end
+    K,V = _merge_kvtypes(d, others...)
     merge!(combine, OrderedDict{K,V}(), d, others...)
 end

--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -337,7 +337,7 @@ function get!(default::Base.Callable, h::OrderedDict{K,V}, key0) where {K,V}
 
     h.dirty = false
     v = convert(V,  default())
-    if h.dirty
+    if h.dirty  # calling default could have dirtied h
         index = ht_keyindex2(h, key)
     end
     if index > 0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using Random, Serialization
 @test isempty(detect_ambiguities(Base, Core, OrderedCollections))
 
 tests = [
+         "little_dict",
          "ordered_dict",
          "ordered_set",
         ]

--- a/test/test_little_dict.jl
+++ b/test/test_little_dict.jl
@@ -455,8 +455,9 @@ end # @testset LittleDict
         @test base_dict == nonfrozen
 
         frozen = freeze(nonfrozen)
-        @test frozen == base_dict
         @test frozen isa LittleDict{Int, String, <:Tuple, <:Tuple}
+        @test frozen == base_dict
+        @test frozen === base_dict
     end
 
     @testset "get" begin

--- a/test/test_little_dict.jl
+++ b/test/test_little_dict.jl
@@ -27,8 +27,11 @@ using OrderedCollections, Test
 
         k_iter = Iterators.filter(x->x>1, [1,2,3,4])
         v_iter = Iterators.filter(x->x>1, [1.0,2.0,3.0,4.0])
-        @test @inferred(LittleDict(k_iter, v_iter)) isa LittleDict{Int,Float64, Vector{Int}, Vector{Float64}}
+        @test @inferred(LittleDict(k_iter, v_iter)) isa
+            LittleDict{Int,Float64, Vector{Int}, Vector{Float64}}
 
+        @test @inferred(LittleDict{Int, Char}(rand(1:100,20), rand('a':'z', 20))) isa
+            LittleDict{Int64,Char,Array{Int64,1},Array{Char,1}}
     end
     
     @testset "empty dictionary" begin

--- a/test/test_little_dict.jl
+++ b/test/test_little_dict.jl
@@ -32,6 +32,9 @@ using OrderedCollections, Test
 
         @test @inferred(LittleDict{Int, Char}(rand(1:100,20), rand('a':'z', 20))) isa
             LittleDict{Int64,Char,Array{Int64,1},Array{Char,1}}
+
+        # Different number of keys and values
+        @test_throws ArgumentError LittleDict{Int, Char, Vector{Int}, Vector{Char}}([1,2,3], ['a','b'])
     end
     
     @testset "empty dictionary" begin

--- a/test/test_little_dict.jl
+++ b/test/test_little_dict.jl
@@ -1,6 +1,43 @@
 using OrderedCollections, Test
+using OrderedCollections: FrozenLittleDict, UnfrozenLittleDict
 
 @testset "LittleDict" begin
+    @testset "Type Aliases" begin
+        FF1 = LittleDict{Int,Int, NTuple{10, Int}, NTuple{10, Int}}
+        @test FF1 <: FrozenLittleDict{<:Any, <:Any}
+        @test FF1 <: FrozenLittleDict
+        @test FF1 <: FrozenLittleDict{Int, Int}
+        @test !(FF1 <: UnfrozenLittleDict{<:Any, <:Any})
+        @test !(FF1 <: UnfrozenLittleDict)
+        @test !(FF1 <: UnfrozenLittleDict{Int, Int})
+
+
+        UU1 = LittleDict{Int,Int,Vector{Int},Vector{Int}}
+        @test !(UU1 <: FrozenLittleDict{<:Any, <:Any})
+        @test !(UU1 <: FrozenLittleDict)
+        @test !(UU1 <: FrozenLittleDict{Int, Int})
+        @test (UU1 <: UnfrozenLittleDict{<:Any, <:Any})
+        @test (UU1 <: UnfrozenLittleDict)
+        @test (UU1 <: UnfrozenLittleDict{Int, Int})
+
+
+        FU1 = LittleDict{Int,Int,NTuple{10, Int},Vector{Int}}
+        @test !(FU1 <: FrozenLittleDict{<:Any, <:Any})
+        @test !(FU1 <: FrozenLittleDict)
+        @test !(FU1 <: FrozenLittleDict{Int, Int})
+        @test !(FU1 <: UnfrozenLittleDict{<:Any, <:Any})
+        @test !(FU1 <: UnfrozenLittleDict)
+        @test !(FU1 <: UnfrozenLittleDict{Int, Int})
+
+        UF1 = LittleDict{Int,Int,Vector{Int},NTuple{10,Int}}
+        @test !(UF1 <: FrozenLittleDict{<:Any, <:Any})
+        @test !(UF1 <: FrozenLittleDict)
+        @test !(UF1 <: FrozenLittleDict{Int, Int})
+        @test !(UF1 <: UnfrozenLittleDict{<:Any, <:Any})
+        @test !(UF1 <: UnfrozenLittleDict)
+        @test !(UF1 <: UnfrozenLittleDict{Int, Int})
+    end
+
     @testset "Constructors" begin
         @test isa(@inferred(LittleDict()), LittleDict{Any,Any})
         @test isa(@inferred(LittleDict([(1,2.0)])), LittleDict{Int,Float64})
@@ -36,7 +73,8 @@ using OrderedCollections, Test
         # Different number of keys and values
         @test_throws ArgumentError LittleDict{Int, Char, Vector{Int}, Vector{Char}}([1,2,3], ['a','b'])
     end
-    
+
+
     @testset "empty dictionary" begin
         d = LittleDict{Char, Int}()
         @test length(d) == 0

--- a/test/test_little_dict.jl
+++ b/test/test_little_dict.jl
@@ -1,0 +1,423 @@
+using OrderedCollections, Test
+
+@testset "LittleDict" begin
+@testset "Constructors" begin
+    @test isa(@inferred(LittleDict()), LittleDict{Any,Any})
+    @test isa(@inferred(LittleDict([(1,2.0)])), LittleDict{Int,Float64})
+
+    @test isa(@inferred(LittleDict([("a",1),("b",2)])), LittleDict{String,Int})
+    @test isa(@inferred(LittleDict(Pair(1, 1.0))), LittleDict{Int,Float64})
+    @test isa(@inferred(LittleDict(Pair(1, 1.0), Pair(2, 2.0))), 
+    LittleDict{Int,Float64})
+
+    @test isa(@inferred(LittleDict{Int,Float64}(2=>2.0, 3=>3.0)), 
+        LittleDict{Int,Float64})
+    @test isa(@inferred(LittleDict{Int,Float64}(Pair(1, 1), Pair(2, 2))), LittleDict{Int,Float64})
+    @test isa(@inferred(LittleDict(Pair(1, 1.0), Pair(2, 2.0), Pair(3, 3.0))), LittleDict{Int,Float64})
+    @test LittleDict(()) == LittleDict{Any,Any}()
+
+    @test isa(@inferred(LittleDict([Pair(1, 1.0), Pair(2, 2.0)])), LittleDict{Int,Float64})
+    @test_throws ArgumentError LittleDict([1,2,3,4])
+
+    iter = Iterators.filter(x->x.first>1, [Pair(1, 1.0), Pair(2, 2.0), Pair(3, 3.0)])
+    @test @inferred(LittleDict(iter)) == LittleDict{Int,Float64}(2=>2.0, 3=>3.0)
+    
+    iter = Iterators.drop(1:10, 1)
+    @test_throws ArgumentError LittleDict(iter)
+end
+    
+
+
+    @testset "empty dictionary" begin
+        d = LittleDict{Char, Int}()
+        @test length(d) == 0
+        @test isempty(d)
+        @test_throws KeyError d['c'] == 1
+        d['c'] = 1
+        @test !isempty(d)
+        @test_throws KeyError d[0.01]
+        @test isempty(empty(d))
+        empty!(d)
+        @test isempty(d)
+
+        # access, modification
+        for c in 'a':'z'
+            d[c] = c - 'a' + 1
+        end
+
+        @test (d['a'] += 1) == 2
+        @test 'a' in keys(d)
+        @test haskey(d, 'a')
+        @test get(d, 'B', 0) == 0
+        @test getkey(d, 'b', nothing) == 'b'
+        @test getkey(d, 'B', nothing) == nothing
+        @test !('B' in keys(d))
+        @test !haskey(d, 'B')
+        @test pop!(d, 'a') == 2
+
+        @test collect(keys(d)) == collect('b':'z')
+        @test collect(values(d)) == collect(2:26)
+        @test collect(d) == [Pair(a,i) for (a,i) in zip('b':'z', 2:26)]
+    end
+
+    @testset "convert" begin
+        d = LittleDict{Int,Float32}(i=>Float32(i) for i = 1:10)
+        @test convert(LittleDict{Int,Float32}, d) === d
+        dc = convert(LittleDict{Int,Float64}, d)
+        @test dc !== d
+        @test keytype(dc) == Int
+        @test valtype(dc) == Float64
+        @test keys(dc) == keys(d)
+        @test collect(values(dc)) == collect(values(d))
+    end
+
+    @testset "Issue #60" begin
+        od60 = LittleDict{Int,Int}()
+        od60[1] = 2
+
+        ranges = [2:5, 6:9, 10:13]
+        for range in ranges
+            for i = range
+                od60[i] = i+1
+            end
+            for i = range
+                delete!( od60, i )
+            end
+        end
+        od60[14]=15
+
+        @test od60[14] == 15
+    end
+
+
+    ##############################
+    # Copied and modified from Base/test/dict.jl
+
+    # LittleDict
+
+    @testset "LittleDict{Int,Int}" begin
+        h = LittleDict{Int,Int}()
+        for i=1:100
+            h[i] = i+1
+        end
+
+        @test collect(h) == [Pair(x,y) for (x,y) in zip(1:100, 2:10001)]
+
+        for i=1:2:100
+            delete!(h, i)
+        end
+        for i=1:2:100
+            h[i] = i+1
+        end
+
+        for i=1:100
+            @test h[i]==i+1
+        end
+
+        for i=1:100
+            delete!(h, i)
+        end
+        @test isempty(h)
+
+        h[77] = 100
+        @test h[77]==100
+
+        for i=1:100
+            h[i] = i+1
+        end
+
+        for i=1:2:100
+            delete!(h, i)
+        end
+
+        for i=101:200
+            h[i] = i+1
+        end
+
+        for i=2:2:100
+            @test h[i]==i+1
+        end
+
+        for i=10:200
+            @test h[i]==i+1
+        end
+    end
+
+    @testset "LittleDict{Any,Any}" begin
+        h = LittleDict{Any,Any}([("a", 3)])
+        @test h["a"] == 3
+        h["a","b"] = 4
+        @test h["a","b"] == h[("a","b")] == 4
+        h["a","b","c"] = 4
+        @test h["a","b","c"] == h[("a","b","c")] == 4
+    end
+
+    @testset "KeyError" begin
+        z = LittleDict()
+        get_KeyError = false
+        try
+            z["a"]
+        catch _e123_
+            get_KeyError = isa(_e123_, KeyError)
+        end
+        @test get_KeyError
+    end
+
+    @testset "filter" begin
+        _d = LittleDict([("a", 0)])
+        v = [k for k in filter(x->length(x)==1, collect(keys(_d)))]
+        @test isa(v, Vector{String})
+    end
+
+    @testset "from tuple/vector/pairs/tuple of pair 1" begin
+        d = LittleDict(((1, 2), (3, 4)))
+        d2 = LittleDict([(1, 2), (3, 4)])
+        d3 = LittleDict(1 => 2, 3 => 4)
+        d4 = LittleDict((1 => 2, 3 => 4))
+
+        @test d[1] === 2
+        @test d[3] === 4
+
+        @test d == d2 == d3 == d4
+        @test isa(d, LittleDict{Int,Int})
+        @test isa(d2, LittleDict{Int,Int})
+        @test isa(d3, LittleDict{Int,Int})
+        @test isa(d4, LittleDict{Int,Int})
+    end
+
+    @testset "from tuple/vector/pairs/tuple of pair 2" begin
+        d = LittleDict(((1, 2), (3, "b")))
+        d2 = LittleDict([(1, 2), (3, "b")])
+        d3 = LittleDict(1 => 2, 3 => "b")
+        d4 = LittleDict((1 => 2, 3 => "b"))
+
+        @test d2[1] === 2
+        @test d2[3] == "b"
+
+        ## TODO: tuple of tuples doesn't work for mixed tuple types
+        # @test d == d2 == d3 == d4
+        # @test isa(d, LittleDict{Int,Any})
+        @test d2 == d3 == d4
+        @test isa(d2, LittleDict{Int,Any})
+        @test isa(d3, LittleDict{Int,Any})
+        @test isa(d4, LittleDict{Int,Any})
+    end
+
+    @testset "from tuple/vector/pairs/tuple of pair 3" begin
+        d = LittleDict(((1, 2), ("a", 4)))
+        d2 = LittleDict([(1, 2), ("a", 4)])
+        d3 = LittleDict(1 => 2, "a" => 4)
+        d4 = LittleDict((1 => 2, "a" => 4))
+
+        @test d2[1] === 2
+        @test d2["a"] === 4
+
+        ## TODO: tuple of tuples doesn't work for mixed tuple types
+        # @test d == d2 == d3 == d4
+        @test d2 == d3 == d4
+        # @test isa(d, LittleDict{Any,Int})
+        @test isa(d2, LittleDict{Any,Int})
+        @test isa(d3, LittleDict{Any,Int})
+        @test isa(d4, LittleDict{Any,Int})
+    end
+
+    @testset "from tuple/vector/pairs/tuple of pair 4" begin
+        d = LittleDict(((1, 2), ("a", "b")))
+        d2 = LittleDict([(1, 2), ("a", "b")])
+        d3 = LittleDict(1 => 2, "a" => "b")
+        d4 = LittleDict((1 => 2, "a" => "b"))
+
+        @test d[1] === 2
+        @test d["a"] == "b"
+
+        @test d == d2 == d3 == d4
+        @test isa(d, LittleDict{Any,Any})
+        @test isa(d2, LittleDict{Any,Any})
+        @test isa(d3, LittleDict{Any,Any})
+        @test isa(d4, LittleDict{Any,Any})
+    end
+
+    @testset "first" begin
+        @test_throws ArgumentError first(LittleDict())
+        @test first(LittleDict([(:f, 2)])) == Pair(:f,2)
+    end
+
+    @testset "Issue #1821" begin
+        d = LittleDict{String, Vector{Int}}()
+        d["a"] = [1, 2]
+        @test_throws MethodError d["b"] = 1
+        @test isa(repr(d), AbstractString)  # check that printable without error
+    end
+
+    @testset "Issue #2344" begin
+        bestkey(d, key) = key
+        bestkey(d::AbstractDict{K,V}, key) where {K<:AbstractString,V} = string(key)
+        bar(x) = bestkey(x, :y)
+        @test bar(LittleDict([(:x, [1,2,5])])) == :y
+        @test bar(LittleDict([("x", [1,2,5])])) == "y"
+    end
+
+    @testset "isequal" begin
+        @test  isequal(LittleDict(), LittleDict())
+        @test  isequal(LittleDict([(1, 1)]), LittleDict([(1, 1)]))
+        @test !isequal(LittleDict([(1, 1)]), LittleDict())
+        @test !isequal(LittleDict([(1, 1)]), LittleDict([(1, 2)]))
+        @test !isequal(LittleDict([(1, 1)]), LittleDict([(2, 1)]))
+
+        @test isequal(LittleDict(), sizehint!(LittleDict(),96))
+
+        # Here is what currently happens when dictionaries of different types
+        # are compared. This is not necessarily desirable. These tests are
+        # descriptive rather than proscriptive.
+        @test !isequal(LittleDict([(1, 2)]), LittleDict([("dog", "bone")]))
+        @test isequal(LittleDict{Int,Int}(), LittleDict{AbstractString,AbstractString}())
+    end
+
+    @testset "data_in" begin
+        # Generate some data to populate dicts to be compared
+        data_in = [ (rand(1:1000), randstring(2)) for _ in 1:1001 ]
+
+        # Populate the first dict
+        d1 = LittleDict{Int, String}()
+        for (k,v) in data_in
+            d1[k] = v
+        end
+        data_in = collect(d1)
+        # shuffle the data
+        for i in 1:length(data_in)
+            j = rand(1:length(data_in))
+            data_in[i], data_in[j] = data_in[j], data_in[i]
+        end
+        # Inserting data in different (shuffled) order should result in
+        # equivalent dict.
+        d2 = LittleDict{Int, AbstractString}()
+        for (k,v) in data_in
+            d2[k] = v
+        end
+
+        @test  isequal(d1, d2)
+        d3 = copy(d2)
+        d4 = copy(d2)
+        # Removing an item gives different dict
+        delete!(d1, data_in[rand(1:length(data_in))][1])
+        @test !isequal(d1, d2)
+        # Changing a value gives different dict
+        d3[data_in[rand(1:length(data_in))][1]] = randstring(3)
+        !isequal(d1, d3)
+        # Adding a pair gives different dict
+        d4[1001] = randstring(3)
+        @test !isequal(d1, d4)
+    end
+
+    @testset "get!" begin
+        # get! (get with default values assigned to the given location)
+        f(x) = x^2
+        d = LittleDict(8 => 19)
+
+        @test get!(d, 8, 5) == 19
+        @test get!(d, 19, 2) == 2
+
+        @test get!(d, 42) do  # d is updated with f(2)
+            f(2)
+        end == 4
+
+        @test get!(d, 42) do  # d is not updated
+            f(200)
+        end == 4
+
+        @test get(d, 13) do   # d is not updated
+            f(4)
+        end == 16
+
+        @test d == LittleDict(8=>19, 19=>2, 42=>4)
+    end
+
+    @testset "Issue #5886" begin
+        d5886 = LittleDict()
+        for k5886 in 1:11
+            d5886[k5886] = 1
+        end
+        for k5886 in keys(d5886)
+            # undefined ref if not fixed
+            d5886[k5886] += 1
+        end
+    end
+
+    @testset "Issue #216" begin
+        @test OrderedCollections.isordered(LittleDict{Int, String})
+        @test !OrderedCollections.isordered(Dict{Int, String})
+    end
+
+    @testset "Test merging" begin
+        a = LittleDict("foo"  => 0.0, "bar" => 42.0)
+        b = LittleDict("フー" => 17, "バー" => 4711)
+        @test isa(merge(a, b), LittleDict{String,Float64})
+    end
+
+    @testset "Issue #9295" begin
+        d = LittleDict()
+        @test push!(d, 'a'=> 1) === d
+        @test d['a'] == 1
+        @test push!(d, 'b' => 2, 'c' => 3) === d
+        @test d['b'] == 2
+        @test d['c'] == 3
+        @test push!(d, 'd' => 4, 'e' => 5, 'f' => 6) === d
+        @test d['d'] == 4
+        @test d['e'] == 5
+        @test d['f'] == 6
+        @test length(d) == 6
+    end
+
+    @testset "Serialization" begin
+        s = IOBuffer()
+        od = LittleDict{Char,Int64}()
+        for c in 'a':'e'
+            od[c] = c-'a'+1
+        end
+        serialize(s, od)
+        seek(s, 0)
+        dd = deserialize(s)
+        @test isa(dd, OrderedCollections.LittleDict{Char,Int64})
+        @test dd == od
+        close(s)
+    end
+
+    @testset "Issue #148" begin
+        d148 = LittleDict(
+                    :gps => [],
+                    :direction => 1:8,
+                    :weather => 1:10
+            )
+
+        d148_2 = LittleDict(
+            :time => 1:10,
+            :features => LittleDict(
+                :gps => 1:5,
+                :direction => 1:8,
+                :weather => 1:10
+            )
+        )
+    end
+
+    @testset "Issue #400" begin
+        @test filter(p->first(p) > 1, LittleDict(1=>2, 3=>4)) isa LittleDict
+    end
+
+    @testset "Sorting" begin
+        d = Dict(i=>Char(123-i) for i = 1:10)
+        @test collect(keys(d)) != 1:10
+        sd = sort(d)
+        @test collect(keys(sd)) == 1:10
+        @test collect(values(sd)) == collect('z':-1:'q')
+        @test sort(sd) == sd
+        sdv = sort(d; byvalue=true)
+        @test collect(keys(sdv)) == 10:-1:1
+        @test collect(values(sdv)) == collect('q':'z')
+    end
+
+    @testset "Test that LittleDict merge with combiner returns type LittleDict" begin
+        @test merge(+, LittleDict(:a=>1, :b=>2), LittleDict(:b=>7, :c=>4)) == LittleDict(:a=>1, :b=>9, :c=>4)
+        @test merge(+, LittleDict(:a=>1, :b=>2), Dict(:b=>7, :c=>4)) isa LittleDict
+    end
+
+end # @testset LittleDict

--- a/test/test_little_dict.jl
+++ b/test/test_little_dict.jl
@@ -24,6 +24,11 @@ using OrderedCollections, Test
         
         iter = Iterators.drop(1:10, 1)
         @test_throws ArgumentError LittleDict(iter)
+
+        k_iter = Iterators.filter(x->x>1, [1,2,3,4])
+        v_iter = Iterators.filter(x->x>1, [1.0,2.0,3.0,4.0])
+        @test @inferred(LittleDict(k_iter, v_iter)) isa LittleDict{Int,Float64, Vector{Int}, Vector{Float64}}
+
     end
     
     @testset "empty dictionary" begin

--- a/test/test_little_dict.jl
+++ b/test/test_little_dict.jl
@@ -1,33 +1,31 @@
 using OrderedCollections, Test
 
 @testset "LittleDict" begin
-@testset "Constructors" begin
-    @test isa(@inferred(LittleDict()), LittleDict{Any,Any})
-    @test isa(@inferred(LittleDict([(1,2.0)])), LittleDict{Int,Float64})
+    @testset "Constructors" begin
+        @test isa(@inferred(LittleDict()), LittleDict{Any,Any})
+        @test isa(@inferred(LittleDict([(1,2.0)])), LittleDict{Int,Float64})
 
-    @test isa(@inferred(LittleDict([("a",1),("b",2)])), LittleDict{String,Int})
-    @test isa(@inferred(LittleDict(Pair(1, 1.0))), LittleDict{Int,Float64})
-    @test isa(@inferred(LittleDict(Pair(1, 1.0), Pair(2, 2.0))), 
-    LittleDict{Int,Float64})
-
-    @test isa(@inferred(LittleDict{Int,Float64}(2=>2.0, 3=>3.0)), 
+        @test isa(@inferred(LittleDict([("a",1),("b",2)])), LittleDict{String,Int})
+        @test isa(@inferred(LittleDict(Pair(1, 1.0))), LittleDict{Int,Float64})
+        @test isa(@inferred(LittleDict(Pair(1, 1.0), Pair(2, 2.0))),
         LittleDict{Int,Float64})
-    @test isa(@inferred(LittleDict{Int,Float64}(Pair(1, 1), Pair(2, 2))), LittleDict{Int,Float64})
-    @test isa(@inferred(LittleDict(Pair(1, 1.0), Pair(2, 2.0), Pair(3, 3.0))), LittleDict{Int,Float64})
-    @test LittleDict(()) == LittleDict{Any,Any}()
 
-    @test isa(@inferred(LittleDict([Pair(1, 1.0), Pair(2, 2.0)])), LittleDict{Int,Float64})
-    @test_throws ArgumentError LittleDict([1,2,3,4])
+        @test isa(@inferred(LittleDict{Int,Float64}(2=>2.0, 3=>3.0)),
+            LittleDict{Int,Float64})
+        @test isa(@inferred(LittleDict{Int,Float64}(Pair(1, 1), Pair(2, 2))), LittleDict{Int,Float64})
+        @test isa(@inferred(LittleDict(Pair(1, 1.0), Pair(2, 2.0), Pair(3, 3.0))), LittleDict{Int,Float64})
+        @test LittleDict(()) == LittleDict{Any,Any}()
 
-    iter = Iterators.filter(x->x.first>1, [Pair(1, 1.0), Pair(2, 2.0), Pair(3, 3.0)])
-    @test @inferred(LittleDict(iter)) == LittleDict{Int,Float64}(2=>2.0, 3=>3.0)
+        @test isa(@inferred(LittleDict([Pair(1, 1.0), Pair(2, 2.0)])), LittleDict{Int,Float64})
+        @test_throws ArgumentError LittleDict([1,2,3,4])
+
+        iter = Iterators.filter(x->x.first>1, [Pair(1, 1.0), Pair(2, 2.0), Pair(3, 3.0)])
+        @test @inferred(LittleDict(iter)) == LittleDict{Int,Float64}(2=>2.0, 3=>3.0)
+        
+        iter = Iterators.drop(1:10, 1)
+        @test_throws ArgumentError LittleDict(iter)
+    end
     
-    iter = Iterators.drop(1:10, 1)
-    @test_throws ArgumentError LittleDict(iter)
-end
-    
-
-
     @testset "empty dictionary" begin
         d = LittleDict{Char, Int}()
         @test length(d) == 0
@@ -60,6 +58,7 @@ end
         @test collect(d) == [Pair(a,i) for (a,i) in zip('b':'z', 2:26)]
     end
 
+    exit()
     @testset "convert" begin
         d = LittleDict{Int,Float32}(i=>Float32(i) for i = 1:10)
         @test convert(LittleDict{Int,Float32}, d) === d

--- a/test/test_little_dict.jl
+++ b/test/test_little_dict.jl
@@ -352,7 +352,7 @@ using OrderedCollections, Test
         end
     end
 
-    @testset "Issue #216" begin
+    @testset "isordered (Issue #216)1" begin
         @test OrderedCollections.isordered(LittleDict{Int, String})
         @test !OrderedCollections.isordered(Dict{Int, String})
     end
@@ -413,7 +413,8 @@ using OrderedCollections, Test
     end
 
     @testset "Sorting" begin
-        d = Dict(i=>Char(123-i) for i = 1:10)
+        d = LittleDict(i=>Char(123-i) for i in [4, 8, 1, 7, 9, 3, 10, 2, 6, 5])
+        
         @test collect(keys(d)) != 1:10
         sd = sort(d)
         @test collect(keys(sd)) == 1:10
@@ -428,5 +429,4 @@ using OrderedCollections, Test
         @test merge(+, LittleDict(:a=>1, :b=>2), LittleDict(:b=>7, :c=>4)) == LittleDict(:a=>1, :b=>9, :c=>4)
         @test merge(+, LittleDict(:a=>1, :b=>2), Dict(:b=>7, :c=>4)) isa LittleDict
     end
-
 end # @testset LittleDict

--- a/test/test_little_dict.jl
+++ b/test/test_little_dict.jl
@@ -58,7 +58,6 @@ using OrderedCollections, Test
         @test collect(d) == [Pair(a,i) for (a,i) in zip('b':'z', 2:26)]
     end
 
-    exit()
     @testset "convert" begin
         d = LittleDict{Int,Float32}(i=>Float32(i) for i = 1:10)
         @test convert(LittleDict{Int,Float32}, d) === d
@@ -100,7 +99,7 @@ using OrderedCollections, Test
             h[i] = i+1
         end
 
-        @test collect(h) == [Pair(x,y) for (x,y) in zip(1:100, 2:10001)]
+        @test collect(h) == [Pair(x,y) for (x,y) in zip(1:100, 2:101)]
 
         for i=1:2:100
             delete!(h, i)
@@ -120,24 +119,27 @@ using OrderedCollections, Test
 
         h[77] = 100
         @test h[77]==100
+        @test length(h) == 1
 
         for i=1:100
             h[i] = i+1
         end
+        @test length(h) == 100
 
-        for i=1:2:100
+        for i=1:2:50
             delete!(h, i)
         end
+        @test length(h) == 75
 
-        for i=101:200
+        for i=51:100
             h[i] = i+1
         end
+        @test length(h) == 75
 
         for i=2:2:100
             @test h[i]==i+1
         end
-
-        for i=10:200
+        for i=75:100
             @test h[i]==i+1
         end
     end
@@ -150,7 +152,7 @@ using OrderedCollections, Test
         h["a","b","c"] = 4
         @test h["a","b","c"] == h[("a","b","c")] == 4
     end
-
+    
     @testset "KeyError" begin
         z = LittleDict()
         get_KeyError = false
@@ -183,7 +185,7 @@ using OrderedCollections, Test
         @test isa(d3, LittleDict{Int,Int})
         @test isa(d4, LittleDict{Int,Int})
     end
-
+    
     @testset "from tuple/vector/pairs/tuple of pair 2" begin
         d = LittleDict(((1, 2), (3, "b")))
         d2 = LittleDict([(1, 2), (3, "b")])
@@ -193,10 +195,8 @@ using OrderedCollections, Test
         @test d2[1] === 2
         @test d2[3] == "b"
 
-        ## TODO: tuple of tuples doesn't work for mixed tuple types
-        # @test d == d2 == d3 == d4
-        # @test isa(d, LittleDict{Int,Any})
-        @test d2 == d3 == d4
+        @test d == d2 == d3 == d4
+        @test isa(d, LittleDict{Int,Any})
         @test isa(d2, LittleDict{Int,Any})
         @test isa(d3, LittleDict{Int,Any})
         @test isa(d4, LittleDict{Int,Any})
@@ -271,6 +271,7 @@ using OrderedCollections, Test
         @test !isequal(LittleDict([(1, 2)]), LittleDict([("dog", "bone")]))
         @test isequal(LittleDict{Int,Int}(), LittleDict{AbstractString,AbstractString}())
     end
+
 
     @testset "data_in" begin
         # Generate some data to populate dicts to be compared

--- a/test/test_little_dict.jl
+++ b/test/test_little_dict.jl
@@ -241,7 +241,16 @@ using OrderedCollections, Test
         @test first(LittleDict([(:f, 2)])) == Pair(:f,2)
     end
 
-    @testset "Issue #1821" begin
+
+    @testset "iterate" begin
+        d = LittleDict("a" => [1, 2])
+        val1, state1 = iterate(d)
+        @test val1 == ("a" => [1, 2])
+        @test iterate(d, state1) === nothing
+    end
+
+
+    @testset "Failing to add a value but being able to add a key (cf: Issue #1821)" begin
         d = LittleDict{String, Vector{Int}}()
         d["a"] = [1, 2]
         @test_throws MethodError d["b"] = 1

--- a/test/test_little_dict.jl
+++ b/test/test_little_dict.jl
@@ -68,7 +68,7 @@ using OrderedCollections: FrozenLittleDict, UnfrozenLittleDict
             LittleDict{Int,Float64, Vector{Int}, Vector{Float64}}
 
         @test @inferred(LittleDict{Int, Char}(rand(1:100,20), rand('a':'z', 20))) isa
-            LittleDict{Int64,Char,Array{Int64,1},Array{Char,1}}
+            LittleDict{Int,Char,Array{Int,1},Array{Char,1}}
 
         # Different number of keys and values
         @test_throws ArgumentError LittleDict{Int, Char, Vector{Int}, Vector{Char}}([1,2,3], ['a','b'])

--- a/test/test_little_dict.jl
+++ b/test/test_little_dict.jl
@@ -430,3 +430,37 @@ using OrderedCollections, Test
         @test merge(+, LittleDict(:a=>1, :b=>2), Dict(:b=>7, :c=>4)) isa LittleDict
     end
 end # @testset LittleDict
+
+
+@testset "Frozen LittleDict" begin
+
+    @testset "types" begin
+        base_dict = LittleDict((10,20,30),("a", "b", "c"))
+        @test base_dict isa LittleDict{Int, String, <:Tuple, <:Tuple}
+        
+        nonfrozen = LittleDict(10=>"a", 20=>"b", 30=>"c")
+        @test nonfrozen isa LittleDict{Int, String, <:Vector, <:Vector}
+        
+        @test base_dict == nonfrozen
+
+        frozen = freeze(nonfrozen)
+        @test frozen == base_dict
+        @test frozen isa LittleDict{Int, String, <:Tuple, <:Tuple}
+    end
+
+    @testset "get" begin
+        fd = LittleDict((10,20,30),("a", "b", "c"))
+        @test fd[10] == "a"
+        @test fd[20] == "b"
+        @test fd[30] == "c"
+        @test_throws KeyError fd[-1]
+    end
+
+    @testset "set" begin
+        fd = LittleDict((10,20,30),("a", "b", "c"))
+        @test_throws MethodError fd[10] = "ab"
+        @test_throws MethodError fd[20] = "bb"
+        @test_throws MethodError fd[30] = "cc"
+        @test_throws MethodError fd[-1] = "dd"
+    end
+end


### PR DESCRIPTION
This PR adds a new type `LittleDict`.
It is optized for small numbers of elements
My timing on a earlier version* had it hitting parity with `OrderedDict` for `Symbol` keys, at 30 elements when backed with a `Vector` or 50  elements when backed with a `Tuple`.

I would like to put it in OrderedCollections.jl because

 - A) it is an ordered collection
 - B) many uses of `OrderedDict` right now, would be better off using `LittleDict`. (Basically all my . previous uses. Though I may be a nonrepresentative sample.)


TODO is tests, and a bit more API, esp constructors.
But I will let the tests driive those.
I want to basically reuse the OrderedDict tests, (except the ones that involve 10,000 elements)
but I am undecided as to if that should be via copy-paste,
or via adding abstraction to the current testset.


* (Timing done on a version that was 30% slower than the one in this PR)