### PR TITLE
Add support for map!(f,values(d)) to OrderedDict & LittleDict

### DIFF
--- a/src/OrderedCollections.jl
+++ b/src/OrderedCollections.jl
@@ -6,7 +6,7 @@ module OrderedCollections
                  push!, pop!, insert!,
                  union!, delete!, empty, sizehint!,
                  isequal, hash,
-                 map, reverse,
+                 map, map!, reverse,
                  first, last, eltype, getkey, values, sum,
                  merge, merge!, lt, Ordering, ForwardOrdering, Forward,
                  ReverseOrdering, Reverse, Lt,

--- a/src/little_dict.jl
+++ b/src/little_dict.jl
@@ -117,6 +117,15 @@ function Base.getkey(dd::LittleDict, key, default)
     end
 end
 
+function Base.map!(f, iter::Base.ValueIterator{<:LittleDict})
+    dict = iter.dict
+    vals = dict.vals
+    for i = 1:length(vals)
+        @inbounds vals[i] = f(vals[i])
+    end
+    return iter
+end
+
 struct NotFoundSentinel end  # Struct to mark not not found
 function Base.get(dd::LittleDict, key, default)
     @assert length(dd.keys) == length(dd.vals)
@@ -185,7 +194,7 @@ function add_new!(dd::UnfrozenLittleDict{K, V}, key, value) where {K, V}
     # then neither push can fail, so the dict length with remain in sync
     push!(dd.keys, kk)
     push!(dd.vals, vv)
-    
+
     return dd
 end
 
@@ -198,7 +207,7 @@ function Base.setindex!(dd::LittleDict{K,V, <:Any, <:Vector}, value, key) where 
     # setindex! it has huge code (26%), this does mean that if someone has messed
     # with the fields of the LittleDict directly, then the @inbounds could be invalid
     #@assert length(dd.keys) == length(dd.vals)
-    
+
     kk = convert(K, key)
     vv = convert(V, value)
     for ii in 1:length(dd.keys)
@@ -219,7 +228,7 @@ end
 
 function Base.pop!(dd::UnfrozenLittleDict, key)
     @assert length(dd.keys) == length(dd.vals)
-    
+
     for ii in 1:length(dd.keys)
         cand = @inbounds dd.keys[ii]
         if isequal(cand, key)

--- a/src/little_dict.jl
+++ b/src/little_dict.jl
@@ -120,7 +120,7 @@ end
 function Base.map!(f, iter::Base.ValueIterator{<:LittleDict})
     dict = iter.dict
     vals = dict.vals
-    for i = 1:length(vals)
+    for i in 1:length(vals)
         @inbounds vals[i] = f(vals[i])
     end
     return iter

--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -439,3 +439,13 @@ function merge(combine::Function, d::OrderedDict, others::AbstractDict...)
     K,V = _merge_kvtypes(d, others...)
     merge!(combine, OrderedDict{K,V}(), d, others...)
 end
+
+function Base.map!(f, iter::Base.ValueIterator{<:OrderedDict})
+    dict = iter.dict
+    dict.ndel > 0 && rehash!(dict)
+    vals = dict.vals
+    for i = 1:length(vals)
+        @inbounds vals[i] = f(vals[i])
+    end
+    return iter
+end

--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -444,7 +444,7 @@ function Base.map!(f, iter::Base.ValueIterator{<:OrderedDict})
     dict = iter.dict
     dict.ndel > 0 && rehash!(dict)
     vals = dict.vals
-    for i = 1:length(vals)
+    for i in 1:length(vals)
         @inbounds vals[i] = f(vals[i])
     end
     return iter

--- a/test/test_little_dict.jl
+++ b/test/test_little_dict.jl
@@ -58,7 +58,7 @@ using OrderedCollections: FrozenLittleDict, UnfrozenLittleDict
 
         iter = Iterators.filter(x->x.first>1, [Pair(1, 1.0), Pair(2, 2.0), Pair(3, 3.0)])
         @test @inferred(LittleDict(iter)) == LittleDict{Int,Float64}(2=>2.0, 3=>3.0)
-        
+
         iter = Iterators.drop(1:10, 1)
         @test_throws ArgumentError LittleDict(iter)
 
@@ -201,7 +201,7 @@ using OrderedCollections: FrozenLittleDict, UnfrozenLittleDict
         h["a","b","c"] = 4
         @test h["a","b","c"] == h[("a","b","c")] == 4
     end
-    
+
     @testset "KeyError" begin
         z = LittleDict()
         get_KeyError = false
@@ -234,7 +234,7 @@ using OrderedCollections: FrozenLittleDict, UnfrozenLittleDict
         @test isa(d3, LittleDict{Int,Int})
         @test isa(d4, LittleDict{Int,Int})
     end
-    
+
     @testset "from tuple/vector/pairs/tuple of pair 2" begin
         d = LittleDict(((1, 2), (3, "b")))
         d2 = LittleDict([(1, 2), (3, "b")])
@@ -463,7 +463,7 @@ using OrderedCollections: FrozenLittleDict, UnfrozenLittleDict
 
     @testset "Sorting" begin
         d = LittleDict(i=>Char(123-i) for i in [4, 8, 1, 7, 9, 3, 10, 2, 6, 5])
-        
+
         @test collect(keys(d)) != 1:10
         sd = sort(d)
         @test collect(keys(sd)) == 1:10
@@ -486,10 +486,10 @@ end # @testset LittleDict
     @testset "types" begin
         base_dict = LittleDict((10,20,30),("a", "b", "c"))
         @test base_dict isa LittleDict{Int, String, <:Tuple, <:Tuple}
-        
+
         nonfrozen = LittleDict(10=>"a", 20=>"b", 30=>"c")
         @test nonfrozen isa LittleDict{Int, String, <:Vector, <:Vector}
-        
+
         @test base_dict == nonfrozen
 
         frozen = freeze(nonfrozen)
@@ -513,4 +513,10 @@ end # @testset LittleDict
         @test_throws MethodError fd[30] = "cc"
         @test_throws MethodError fd[-1] = "dd"
     end
+    @testset "map!(f, values(LittleDict))" begin
+        testdict = LittleDict(:a=>1, :b=>2)
+        map!(v->v-1, values(testdict))
+        @test testdict[:a] == 0
+        @test testdict[:b] == 1
+end
 end

--- a/test/test_ordered_dict.jl
+++ b/test/test_ordered_dict.jl
@@ -410,5 +410,11 @@ using OrderedCollections, Test
         @test merge(+, OrderedDict(:a=>1, :b=>2), OrderedDict(:b=>7, :c=>4)) == OrderedDict(:a=>1, :b=>9, :c=>4)
         @test merge(+, OrderedDict(:a=>1, :b=>2), Dict(:b=>7, :c=>4)) isa OrderedDict
     end
+    @testset "map!(f, values(OrderedDict))" begin
+            testdict = OrderedDict(:a=>1, :b=>2)
+            map!(v->v-1, values(testdict))
+            @test testdict[:a] == 0
+            @test testdict[:b] == 1
+    end
 
 end # @testset OrderedDict


### PR DESCRIPTION
Add a non-naive implementation of the `map!(f,values(d))` method for inplace value modification to OrderedDict & LittleDict.
`map!(f,values(d))`  was introduced to julia in https://github.com/JuliaLang/julia/pull/31223.