### PR TITLE
remove unnecessary eltype definition

### DIFF
--- a/src/ordered_set.jl
+++ b/src/ordered_set.jl
@@ -19,7 +19,6 @@ isempty(s::OrderedSet) = isempty(s.dict)
 length(s::OrderedSet)  = length(s.dict)
 
 sizehint!(s::OrderedSet, sz::Integer) = (sizehint!(s.dict, sz); s)
-eltype(s::OrderedSet{T}) where {T} = T
 
 in(x, s::OrderedSet) = haskey(s.dict, x)
 


### PR DESCRIPTION
As discussed in https://github.com/JuliaCollections/DataStructures.jl/pull/513#pullrequestreview-260321340. The `eltype` definition for `OrderedSet` is unnecessary since it is a subtype of `AbstractSet` for which `eltype` is already defined correctly.