### PR TITLE
Make delete! for LittleDict be consistent with Dict

### DIFF
--- a/src/little_dict.jl
+++ b/src/little_dict.jl
@@ -248,8 +248,6 @@ function Base.pop!(dd::UnfrozenLittleDict, key)
             return val
         end
     end
-    # Not found, throw error
-    throw(KeyError(key))
 end
 
 function Base.delete!(dd::UnfrozenLittleDict, key)

--- a/test/test_little_dict.jl
+++ b/test/test_little_dict.jl
@@ -86,7 +86,7 @@ using OrderedCollections: FrozenLittleDict, UnfrozenLittleDict
         @test isempty(empty(d))
         empty!(d)
         @test isempty(d)
-        @test delete!(d, "foo") isa Any  # Make sure this does't throw an error
+        @test delete!(d, "foo") == empty(d)  # Make sure this does't throw an error
 
         # access, modification
         for c in 'a':'z'

--- a/test/test_little_dict.jl
+++ b/test/test_little_dict.jl
@@ -86,6 +86,7 @@ using OrderedCollections: FrozenLittleDict, UnfrozenLittleDict
         @test isempty(empty(d))
         empty!(d)
         @test isempty(d)
+        @test delete!(d, "foo") isa Any  # Make sure this does't throw an error
 
         # access, modification
         for c in 'a':'z'


### PR DESCRIPTION
Resolves: #48 

## Problem

When attempting to delete a key from `LittleDict` which does not exist a `KeyError` is thrown. This is inconsistent with behaviour from other data structures such as; `Dict` and `OrderedDict`.

```julia
using OrderedCollections: LittleDict, OrderedDict

delete!(Dict(), "foo")
> Dict{Any,Any} with 0 entries

delete!(OrderedDict(), "foo")
> OrderedDict{Any,Any} with 0 entries

delete!(LittleDict(), "foo")
> ERROR: KeyError: key "foo" not found

```

## Solution

Remove the `throw(KeyError(key))` line.