### PR TITLE
Store maximum probe length in OrderedDicts

### DIFF
--- a/test/test_ordered_dict.jl
+++ b/test/test_ordered_dict.jl
@@ -435,4 +435,19 @@ using OrderedCollections, Test
         @test eltype(OrderedDict(tuple(String => String, SubString => SubString))) == Pair{Type,Type}
     end
 
+    @testset "Issue #71" begin
+        od = OrderedDict(Dict(i=>0 for i=1:158))
+        sort!(od)
+        @test od[158] == 0
+    end
+
+    @testset "Issue #71b" begin
+        # This is actually a simplified version of #60, which was triggered while fixing #71
+        # It doesn't actually fail on previous versions of OrderedCollections
+        od = OrderedDict{Int,Int}(13=>13)
+        delete!( od, 13 )
+        od[14]=14
+        @test od[14] == 14
+    end
+
 end # @testset OrderedDict


### PR DESCRIPTION
* When sorting an OrderedDict, it's possible that the probe length will
  exceed the maximum probe length previously defined.  To prevent this,
  store and use the maximum probe length (and let it grow beyond the
  previously fixed length if needed).

(This idea was borrowed from `Base.Dict`)

Fixes #71 