### PR TITLE
Fix merge for >2 LittleDicts

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OrderedCollections"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-version = "1.4.0"
+version = "1.4.1"
 
 [compat]
 julia = "0.7, 1"

--- a/src/little_dict.jl
+++ b/src/little_dict.jl
@@ -21,7 +21,7 @@ However, this depends on exactly how long `isequal` and `hash` take,
 as well as on how many hash collisions occur etc.
 
 !!! note
-    When constructing a `LittleDict` it is faster to pass in the keys and 
+    When constructing a `LittleDict` it is faster to pass in the keys and
     values each as seperate lists. So if you have them seperately already,
     do `LittleDict(ks, vs)` not `LittleDict(zip(ks, vs))`.
     Further keys or value lists that are passed as `Tuple`s will not require any
@@ -41,7 +41,7 @@ struct LittleDict{K,V,KS<:StoreType,VS<:StoreType} <: AbstractDict{K, V}
         end
         K<:eltype(KS) || ArgumentError("Invalid store type $KS, for key type $K")
         V<:eltype(VS) || ArgumentError("Invalid store type $VS, for value type $K")
-        
+
         return new(keys,vals)
     end
 end
@@ -156,8 +156,8 @@ function Base.iterate(dd::LittleDict, ii=1)
     return (dd.keys[ii] => dd.vals[ii], ii+1)
 end
 
-function merge(d1::LittleDict, d2::AbstractDict)
-    return merge((x,y)->y, d1, d2)
+function merge(d1::LittleDict, others::AbstractDict...)
+    return merge((x,y)->y, d1, others...)
 end
 
 function merge(

--- a/test/test_little_dict.jl
+++ b/test/test_little_dict.jl
@@ -410,7 +410,33 @@ using OrderedCollections: FrozenLittleDict, UnfrozenLittleDict
     @testset "Test merging" begin
         a = LittleDict("foo"  => 0.0, "bar" => 42.0)
         b = LittleDict("フー" => 17, "バー" => 4711)
-        @test isa(merge(a, b), LittleDict{String,Float64})
+        result = merge(a, b)
+        @test isa(result, LittleDict{String,Float64})
+
+        expected = LittleDict("foo"  => 0.0, "bar" => 42.0, "フー" => 17, "バー" => 4711)
+        @test result == expected
+
+        c = LittleDict("a" => 1, "b" => 2, "c" => 3)
+        result = merge(a, b, c)
+        @test isa(result, LittleDict{String,Float64})
+
+        expected = LittleDict(
+            "foo" => 0.0, "bar" => 42.0,
+            "フー" => 17, "バー" => 4711,
+            "a" => 1, "b" => 2, "c" => 3,
+        )
+        @test result == expected
+
+        c = LittleDict("a" => 1, "b" => 2, "foo" => 3)
+        result = merge(a, b, c)
+        @test isa(result, LittleDict{String,Float64})
+
+        expected = LittleDict(
+            "foo" => 3, "bar" => 42.0,
+            "フー" => 17, "バー" => 4711,
+            "a" => 1, "b" => 2,
+        )
+        @test result == expected
     end
 
     @testset "Issue #9295" begin
@@ -526,7 +552,7 @@ end # @testset LittleDict
         @test_throws MethodError fd[30] = "cc"
         @test_throws MethodError fd[-1] = "dd"
     end
-    
+
     @testset "map!(f, values(LittleDict))" begin
         testdict = LittleDict(:a=>1, :b=>2)
         map!(v->v-1, values(testdict))


### PR DESCRIPTION
Closes https://github.com/JuliaCollections/OrderedCollections.jl/issues/78.

Fixes merge so that merging 3 or more `LittleDict`s no longer returns a `Dict`. 
Also adds tests to check merged values are what we expect.