### PR TITLE
Linear indexing for OrderedDict keys() and values().

### DIFF
--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -487,3 +487,13 @@ function Base.map!(f, iter::Base.ValueIterator{<:OrderedDict})
     end
     return iter
 end
+
+# allow indexing of OrderedDict keys and values with `keys(h)[i]` or `values(h)[i]`
+Base.getindex(h::Base.KeySet{K,<:OrderedDict{K}}, index) where K = h.dict.keys[index]
+Base.getindex(h::Base.ValueIterator{<:OrderedDict}, index) = h.dict.vals[index]
+
+Base.firstindex(h::Base.KeySet{K,<:OrderedDict{K}}) where K = firstindex(h.dict.keys)
+Base.firstindex(h::Base.ValueIterator{<:OrderedDict}) = firstindex(h.dict.vals)
+
+Base.lastindex(h::Base.KeySet{K,<:OrderedDict{K}}) where K = lastindex(h.dict.keys)
+Base.lastindex(h::Base.ValueIterator{<:OrderedDict}) = lastindex(h.dict.vals)

--- a/test/test_ordered_dict.jl
+++ b/test/test_ordered_dict.jl
@@ -154,6 +154,14 @@ using OrderedCollections, Test
         @test get_KeyError
     end
 
+    @testset "linear indexing" begin
+        d = OrderedDict{Char,Int}([('a', 10), ('b', 20), ('c', 30)])
+        @test keys(d)[begin] == 'a'
+        @test keys(d)[3] == 'c'
+        @test values(d)[2] == 20
+        @test values(d)[end] == 30
+    end
+
     @testset "filter" begin
         _d = OrderedDict([("a", 0)])
         v = [k for k in filter(x->length(x)==1, collect(keys(_d)))]

--- a/test/test_ordered_dict.jl
+++ b/test/test_ordered_dict.jl
@@ -156,7 +156,7 @@ using OrderedCollections, Test
 
     @testset "linear indexing" begin
         d = OrderedDict{Char,Int}([('a', 10), ('b', 20), ('c', 30)])
-        @test keys(d)[begin] == 'a'
+        @test keys(d)[firstindex(keys(d))] == 'a'
         @test keys(d)[3] == 'c'
         @test values(d)[2] == 20
         @test values(d)[end] == 30


### PR DESCRIPTION
This minimal PR allows `keys(od)[i]` and `values(od)[j]` instead of the equivalent `od.keys[i]` and `od.vals[j]`, where `od isa OrderedDict`.

I often find myself expecting `keys(od)` and `values(od)` to be indexable, preferring this over accessing `od.keys` and `od.vals`, since the latter seems like an implementation detail. Perhaps there is a deliberate design choice against this?