### PR TITLE
Add direct constructor for OrderedDict and OrderedSet

### DIFF
--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -17,37 +17,39 @@ mutable struct OrderedDict{K,V} <: AbstractDict{K,V}
     ndel::Int
     maxprobe::Int
     dirty::Bool
-
-    function OrderedDict{K,V}(slots, keys, vals, ndel, maxprobe, dirty) where {K,V}
-        new{K,V}(slots, keys, vals, ndel, maxprobe, dirty)
-    end
-    function OrderedDict{K,V}() where {K,V}
-        OrderedDict{K,V}(zeros(Int32,16), Vector{K}(), Vector{V}(), 0, 0, false)
-    end
-    function OrderedDict{K,V}(kv) where {K,V}
-        h = OrderedDict{K,V}()
-        for (k,v) in kv
-            h[k] = v
-        end
-        return h
-    end
-    OrderedDict{K,V}(p::Pair) where {K,V} = setindex!(OrderedDict{K,V}(), p.second, p.first)
-    function OrderedDict{K,V}(ps::Pair...) where {K,V}
-        h = OrderedDict{K,V}()
-        sizehint!(h, length(ps))
-        for p in ps
-            h[p.first] = p.second
-        end
-        return h
-    end
-    function OrderedDict{K,V}(d::OrderedDict{K,V}) where {K,V}
-        if d.ndel > 0
-            rehash!(d)
-        end
-        @assert d.ndel == 0
-        OrderedDict{K,V}(copy(d.slots), copy(d.keys), copy(d.vals), 0, d.maxprobe, false)
-    end
 end
+
+function OrderedDict{K,V}() where {K,V}
+    OrderedDict{K,V}(zeros(Int32,16), Vector{K}(), Vector{V}(), 0, 0, false)
+end
+
+function OrderedDict{K,V}(kv) where {K,V}
+    h = OrderedDict{K,V}()
+    for (k,v) in kv
+        h[k] = v
+    end
+    return h
+end
+
+OrderedDict{K,V}(p::Pair) where {K,V} = setindex!(OrderedDict{K,V}(), p.second, p.first)
+
+function OrderedDict{K,V}(ps::Pair...) where {K,V}
+    h = OrderedDict{K,V}()
+    sizehint!(h, length(ps))
+    for p in ps
+        h[p.first] = p.second
+    end
+    return h
+end
+
+function OrderedDict{K,V}(d::OrderedDict{K,V}) where {K,V}
+    if d.ndel > 0
+        rehash!(d)
+    end
+    @assert d.ndel == 0
+    OrderedDict{K,V}(copy(d.slots), copy(d.keys), copy(d.vals), 0, d.maxprobe, false)
+end
+
 OrderedDict() = OrderedDict{Any,Any}()
 OrderedDict(kv::Tuple{}) = OrderedDict()
 copy(d::OrderedDict) = OrderedDict(d)

--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -18,7 +18,7 @@ mutable struct OrderedDict{K,V} <: AbstractDict{K,V}
     maxprobe::Int
     dirty::Bool
 
-    function OrderedDict{K,V}(slots, keys, vals, ndel, maxprobe, dirty)
+    function OrderedDict{K,V}(slots, keys, vals, ndel, maxprobe, dirty) where {K,V}
         new{K,V}(slots, keys, vals, ndel, maxprobe, dirty)
     end
     function OrderedDict{K,V}() where {K,V}

--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -18,8 +18,11 @@ mutable struct OrderedDict{K,V} <: AbstractDict{K,V}
     maxprobe::Int
     dirty::Bool
 
+    function OrderedDict{K,V}(slots, keys, vals, ndel, maxprobe, dirty)
+        new{K,V}(slots, keys, vals, ndel, maxprobe, dirty)
+    end
     function OrderedDict{K,V}() where {K,V}
-        new{K,V}(zeros(Int32,16), Vector{K}(), Vector{V}(), 0, 0, false)
+        OrderedDict{K,V}(zeros(Int32,16), Vector{K}(), Vector{V}(), 0, 0, false)
     end
     function OrderedDict{K,V}(kv) where {K,V}
         h = OrderedDict{K,V}()
@@ -42,7 +45,7 @@ mutable struct OrderedDict{K,V} <: AbstractDict{K,V}
             rehash!(d)
         end
         @assert d.ndel == 0
-        new{K,V}(copy(d.slots), copy(d.keys), copy(d.vals), 0, d.maxprobe, false)
+        OrderedDict{K,V}(copy(d.slots), copy(d.keys), copy(d.vals), 0, d.maxprobe, false)
     end
 end
 OrderedDict() = OrderedDict{Any,Any}()

--- a/src/ordered_set.jl
+++ b/src/ordered_set.jl
@@ -6,7 +6,7 @@
 struct OrderedSet{T}  <: AbstractSet{T}
     dict::OrderedDict{T,Nothing}
 
-    OrderedSet{T}(dict::OrderedDict{T,Nothing}) = new{T}(dict)
+    OrderedSet{T}(dict::OrderedDict{T,Nothing}) where {T} = new{T}(dict)
     OrderedSet{T}() where {T} = new{T}(OrderedDict{T,Nothing}())
     OrderedSet{T}(xs) where {T} = union!(new{T}(OrderedDict{T,Nothing}()), xs)
 end

--- a/src/ordered_set.jl
+++ b/src/ordered_set.jl
@@ -6,6 +6,7 @@
 struct OrderedSet{T}  <: AbstractSet{T}
     dict::OrderedDict{T,Nothing}
 
+    OrderedSet{T}(dict::OrderedDict{T,Nothing}) = new{T}(dict)
     OrderedSet{T}() where {T} = new{T}(OrderedDict{T,Nothing}())
     OrderedSet{T}(xs) where {T} = union!(new{T}(OrderedDict{T,Nothing}()), xs)
 end

--- a/src/ordered_set.jl
+++ b/src/ordered_set.jl
@@ -6,10 +6,18 @@
 struct OrderedSet{T}  <: AbstractSet{T}
     dict::OrderedDict{T,Nothing}
 
-    OrderedSet{T}(dict::OrderedDict{T,Nothing}) where {T} = new{T}(dict)
-    OrderedSet{T}() where {T} = new{T}(OrderedDict{T,Nothing}())
-    OrderedSet{T}(xs) where {T} = union!(new{T}(OrderedDict{T,Nothing}()), xs)
+    function OrderedSet{T}(s::Base.KeySet{T, <:OrderedDict{T}}) where {T}
+        d = s.dict
+        slots = copy(d.slots)
+        keys = copy(d.keys)
+        vals = similar(d.vals, Nothing)
+        new{T}(OrderedDict{T,Nothing}(slots, keys, vals, d.ndel, d.maxprobe, d.dirty))
+    end
 end
+
+OrderedSet{T}() where {T} = OrderedSet{T}(keys(OrderedDict{T,Nothing}()))
+OrderedSet{T}(xs) where {T} = union!(OrderedSet{T}(), xs)
+
 OrderedSet() = OrderedSet{Any}()
 OrderedSet(xs) = OrderedSet{eltype(xs)}(xs)
 

--- a/test/test_ordered_dict.jl
+++ b/test/test_ordered_dict.jl
@@ -3,6 +3,7 @@ using OrderedCollections, Test
 @testset "OrderedDict" begin
 
     @testset "Constructors" begin
+        @test isa(@inferred(OrderedDict{Int,Float64}(zeros(Int,16), Vector{Int}(), Vector{Float64}(), 0, 0, false)), OrderedDict{Int,Float64})
         @test isa(@inferred(OrderedDict()), OrderedDict{Any,Any})
         @test isa(@inferred(OrderedDict([(1,2.0)])), OrderedDict{Int,Float64})
         @test isa(@inferred(OrderedDict([("a",1),("b",2)])), OrderedDict{String,Int})

--- a/test/test_ordered_set.jl
+++ b/test/test_ordered_set.jl
@@ -3,6 +3,8 @@ using OrderedCollections, Test
 @testset "OrderedSet" begin
 
     @testset "Constructors" begin
+        @test isa(OrderedSet{Int}(keys(OrderedDict{Int,Float64}(zeros(Int,16), Vector{Int}(), Vector{Float64}(), 0, 0, false))), OrderedSet{Int})
+        @test isa(OrderedSet{Int}(keys(OrderedDict([(1,2.0)]))), OrderedSet{Int})
         @test isa(OrderedSet(), OrderedSet{Any})
         @test isa(OrderedSet([1,2,3]), OrderedSet{Int})
         @test isa(OrderedSet{Int}([3]), OrderedSet{Int})


### PR DESCRIPTION
This PR simply adds a direct constructor for `OrderedDict` and `OrderedSet`. This is not a breaking change since no current code uses the constructor, and all other constructors remain unchanged. 

This gives package developers the option to, e.g., construct `OrderedDict`s directly from `OrderedSet`s without having to copy large amounts of data as [described in this question on julia discoursse](https://discourse.julialang.org/t/efficiently-construct-a-dictionary-from-a-set/83896). 

Of course, one might ask whether it is safe to allow users to know about the underlying data representing a `struct`, but this change is so small that I can hardly foresee any issues being related to someone using the direct constructor improperly. 