### PR TITLE
add 'last' function for orderedDict.

### DIFF
--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -487,3 +487,11 @@ function Base.map!(f, iter::Base.ValueIterator{<:OrderedDict})
     end
     return iter
 end
+
+function last(h::OrderedDict)
+    h.ndel > 0 && rehash!(h)
+    key = h.keys[end]
+    index = ht_keyindex(h, key, false)
+    @inbounds val = h.vals[h.slots[index]]
+    return key => val
+end

--- a/test/test_ordered_dict.jl
+++ b/test/test_ordered_dict.jl
@@ -233,6 +233,10 @@ using OrderedCollections, Test
         @test first(OrderedDict([(:f, 2)])) == Pair(:f,2)
     end
 
+    @testset "last" begin
+        @test last(OrderedDict([(:f, 2)])) == Pair(:f,2)
+    end
+
     @testset "Issue #1821" begin
         d = OrderedDict{String, Vector{Int}}()
         d["a"] = [1, 2]


### PR DESCRIPTION
Closes: #91 

I haven't added a test for empty `OrderedDict` as I am confused about how to check whether the argument is passed or not.

For the rest, tested the code on my local machine, works fine.

<img width="572" alt="Screenshot 2022-11-15 at 4 03 40 AM" src="https://user-images.githubusercontent.com/64613009/201782166-55ae9796-0452-4e5f-8756-eb1055320d6b.png">
<img width="572" alt="Screenshot 2022-11-15 at 4 04 18 AM" src="https://user-images.githubusercontent.com/64613009/201782283-49f62b4d-0204-49c8-9bb1-d624d03ba759.png">
