### PR TITLE
Remove invalidating method

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OrderedCollections"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-version = "1.5.1"
+version = "1.6.1"
 
 [compat]
 julia = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OrderedCollections"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-version = "1.4.1"
+version = "1.5.1"
 
 [compat]
 julia = "0.7, 1"

--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -107,7 +107,6 @@ function convert(::Type{OrderedDict{K,V}}, d::AbstractDict) where {K,V}
     end
     return h
 end
-convert(::Type{OrderedDict{K,V}},d::OrderedDict{K,V}) where {K,V} = d
 
 isslotempty(slot_value::Integer) = slot_value == 0
 isslotfilled(slot_value::Integer) = slot_value > 0

--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -93,6 +93,7 @@ isordered(::Type{T}) where {T<:OrderedDict} = true
 
 # conversion between OrderedDict types
 function convert(::Type{OrderedDict{K,V}}, d::AbstractDict) where {K,V}
+    d isa OrderedDict{K, V} && return d
     if !isordered(typeof(d))
         Base.depwarn("Conversion to OrderedDict is deprecated for unordered associative containers (in this case, $(typeof(d))). Use an ordered or sorted associative type, such as SortedDict and OrderedDict.", :convert)
     end


### PR DESCRIPTION
```julia
julia> using SnoopCompileCore

julia> invals = @snoopr using DataStructures

julia> using SnoopCompile

julia> trees = invalidation_trees(invals)
2-element Vector{SnoopCompile.MethodInvalidations}:
 inserting Base.IteratorSize(::Type{T} where T<:Union{SortedDict, SortedMultiDict, SortedSet}) @ DataStructures ~/.julia/dev/DataStructures/src/sorted_container_iteration.jl:1038 invalidated:
   backedges: 1: superseding Base.IteratorSize(::Type) @ Base generator.jl:94 with MethodInstance for Base.IteratorSize(::Type{<:AbstractString}) (5 children)
   67 mt_cache

 inserting convert(::Type{OrderedDict{K, V}}, d::OrderedDict{K, V}) where {K, V} @ OrderedCollections ~/.julia/packages/OrderedCollections/PRayh/src/ordered_dict.jl:110 invalidated:
   backedges: 1: superseding convert(::Type{T}, x::T) where T<:AbstractDict @ Base abstractdict.jl:567 with MethodInstance for convert(::Type{T}, ::T) where T<:AbstractDict (2 children)
              2: superseding convert(::Type{T}, x::AbstractDict) where T<:AbstractDict @ Base abstractdict.jl:569 with MethodInstance for convert(::Type{<:AbstractDict}, ::AbstractDict) (6 children)
```