### PR TITLE
Move OrderedSet{T} constructors back as inner constructors

### DIFF
--- a/src/ordered_set.jl
+++ b/src/ordered_set.jl
@@ -6,6 +6,8 @@
 struct OrderedSet{T}  <: AbstractSet{T}
     dict::OrderedDict{T,Nothing}
 
+    OrderedSet{T}() where {T} = new{T}(OrderedDict{T,Nothing}())
+    OrderedSet{T}(xs) where {T} = union!(OrderedSet{T}(), xs)
     function OrderedSet{T}(s::Base.KeySet{T, <:OrderedDict{T}}) where {T}
         d = s.dict
         slots = copy(d.slots)
@@ -14,9 +16,6 @@ struct OrderedSet{T}  <: AbstractSet{T}
         new{T}(OrderedDict{T,Nothing}(slots, keys, vals, d.ndel, d.maxprobe, d.dirty))
     end
 end
-
-OrderedSet{T}() where {T} = OrderedSet{T}(keys(OrderedDict{T,Nothing}()))
-OrderedSet{T}(xs) where {T} = union!(OrderedSet{T}(), xs)
 
 OrderedSet() = OrderedSet{Any}()
 OrderedSet(xs) = OrderedSet{eltype(xs)}(xs)


### PR DESCRIPTION
These were moved to outer constructors in #92 leaving only the constructor from KeySet{<:OrderedDict} as the only (internal) constructor. This change meant, however, that the standard constructors for OrderedSet had to first create an empty OrderedDict to be copied and then thrown away.