### PR TITLE
Shortcut in `sort!(::OrderedDict)` if already sorted

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.6'
           - '1'
 #          - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 version = "1.6.0"
 
 [compat]
-julia = "0.7, 1"
+julia = "1.6"
 
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OrderedCollections"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-version = "1.5.0"
+version = "1.6.0"
 
 [compat]
 julia = "0.7, 1"

--- a/src/dict_sorting.jl
+++ b/src/dict_sorting.jl
@@ -6,11 +6,13 @@ function sort!(d::OrderedDict; byvalue::Bool=false, args...)
         rehash!(d)
     end
 
-    if byvalue
-        p = sortperm(d.vals; args...)
-    else
-        p = sortperm(d.keys; args...)
-    end
+    data = byvalue ? d.vals : d.keys
+
+    # Filter out the kwargs supported by issorted (notably, :alg needs to be removed)
+    issorted_kw = NamedTuple(k => v for (k, v) in args if k in (:lt, :by, :rev, :order))
+    issorted(data; issorted_kw...) && return d
+
+    p = sortperm(data; args...)
     d.keys = d.keys[p]
     d.vals = d.vals[p]
     rehash!(d)


### PR DESCRIPTION
This patch implements a shortcut in `sort!(::OrderedDict)` to return
early in case the dict is already sorted. This avoids allocation of the
permutation vector and new arrays for `keys` and `vals`. This
optimization exist already in Base for sorting arrays, and checking for
sortedness is cheap in comparison to do the sorting.

Note that `sort!(x::OrderedSet)` already has this optimization
implicitly since it uses Base's `sort!` implementation on
`(x.dict.keys)::Vector`.