### PR TITLE
lazy reverse iteration of `OrderedDict`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OrderedCollections"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-version = "1.6.2"
+version = "1.6.3"
 
 [compat]
 julia = "1.6"

--- a/src/little_dict.jl
+++ b/src/little_dict.jl
@@ -156,6 +156,13 @@ function Base.iterate(dd::LittleDict, ii=1)
     return (dd.keys[ii] => dd.vals[ii], ii+1)
 end
 
+# lazy reverse iteration
+function Base.iterate(rdd::Iterators.Reverse{<:LittleDict}, ii=length(rdd.itr.keys))
+    dd = rdd.itr
+    ii < 1 && return nothing
+    return (dd.keys[ii] => dd.vals[ii], ii-1)
+end
+
 function merge(d1::LittleDict, others::AbstractDict...)
     return merge((x,y)->y, d1, others...)
 end

--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -459,6 +459,21 @@ function iterate(t::OrderedDict, i)
     return (Pair(t.keys[i], t.vals[i]), i+1)
 end
 
+# lazy reverse iteration
+function iterate(rt::Iterators.Reverse{<:OrderedDict})
+    t = rt.itr
+    t.ndel > 0 && rehash!(t)
+    n = length(t.keys)
+    n < 1 && return nothing
+    return (Pair(t.keys[n], t.vals[n]), n - 1)
+end
+function iterate(rt::Iterators.Reverse{<:OrderedDict}, i)
+    t = rt.itr
+    i < 1 && return nothing
+    return (Pair(t.keys[i], t.vals[i]), i - 1)
+end
+
+
 function _merge_kvtypes(d, others...)
     K, V = keytype(d), valtype(d)
     for other in others

--- a/src/ordered_set.jl
+++ b/src/ordered_set.jl
@@ -54,6 +54,13 @@ function iterate(s::OrderedSet, i)
     return (s.dict.keys[i], i+1)
 end
 
+# lazy reverse iteration
+function iterate(rs::Iterators.Reverse{<:OrderedSet}, i = length(rs.itr))
+    s = rs.itr
+    i < 1 && return nothing
+    return (s.dict.keys[i], i-1)
+end
+
 pop!(s::OrderedSet) = pop!(s.dict)[1]
 popfirst!(s::OrderedSet) = popfirst!(s.dict)[1]
 

--- a/test/test_little_dict.jl
+++ b/test/test_little_dict.jl
@@ -559,5 +559,18 @@ end # @testset LittleDict
         map!(v->v-1, values(testdict))
         @test testdict[:a] == 0
         @test testdict[:b] == 1
-end
+    end
+
+    @testset "lazy reverse iteration" begin
+        ks = collect('a':'z')
+        vs = collect(0:25)
+        ld = LittleDict(ks, vs)
+        pass = true
+        for (n,(k,v)) in enumerate(Iterators.reverse(ld))
+            pass &= reverse(ks)[n] == k
+            pass &= reverse(vs)[n] == v
+        end
+        @test pass
+    end
+
 end

--- a/test/test_ordered_dict.jl
+++ b/test/test_ordered_dict.jl
@@ -464,14 +464,29 @@ using OrderedCollections, Test
     end
 
     @testset "lazy reverse iteration" begin
-        od = OrderedDict("a"=>1, "b"=>2, "c"=>3)
-        rev_keys = String[]
-        rev_vals = Int[]
-        for (k,v) in Iterators.reverse(od)
-            push!(rev_keys,k)
-            push!(rev_vals,v)
+        ks = collect('a':'z')
+        vs = collect(0:25)
+        od   = OrderedDict(k=>v for (k,v) in zip(ks, vs))
+        pass = true
+        for (n,(k,v)) in enumerate(Iterators.reverse(od))
+            pass &= reverse(ks)[n] == k
+            pass &= reverse(vs)[n] == v
         end
-        @test rev_keys == ["c","b","a"]
-        @test rev_vals == [3,2,1]
+        @test pass
+        # and a set
+        os = OrderedSet(ks)
+        pass = true
+        for (n,k) in enumerate(Iterators.reverse(os))
+            pass &= reverse(ks)[n] == k
+        end
+        @test pass
+        # and LittleDict
+        ld = LittleDict(ks, vs)
+        pass = true
+        for (n,(k,v)) in enumerate(Iterators.reverse(ld))
+            pass &= reverse(ks)[n] == k
+            pass &= reverse(vs)[n] == v
+        end
+        @test pass
     end
 end # @testset OrderedDict

--- a/test/test_ordered_dict.jl
+++ b/test/test_ordered_dict.jl
@@ -473,20 +473,5 @@ using OrderedCollections, Test
             pass &= reverse(vs)[n] == v
         end
         @test pass
-        # and a set
-        os = OrderedSet(ks)
-        pass = true
-        for (n,k) in enumerate(Iterators.reverse(os))
-            pass &= reverse(ks)[n] == k
-        end
-        @test pass
-        # and LittleDict
-        ld = LittleDict(ks, vs)
-        pass = true
-        for (n,(k,v)) in enumerate(Iterators.reverse(ld))
-            pass &= reverse(ks)[n] == k
-            pass &= reverse(vs)[n] == v
-        end
-        @test pass
     end
 end # @testset OrderedDict

--- a/test/test_ordered_dict.jl
+++ b/test/test_ordered_dict.jl
@@ -456,10 +456,22 @@ using OrderedCollections, Test
     end
 
     @testset "ordered access" begin
-        od = OrderedDict(:a=>1, :b=>2, :c=>3)  
+        od = OrderedDict(:a=>1, :b=>2, :c=>3)
         @test popfirst!(od) == (:a => 1)
         @test :a ∉ keys(od)
         @test pop!(od) == (:c => 3)
         @test :c ∉ keys(od)
+    end
+
+    @testset "lazy reverse iteration" begin
+        od = OrderedDict("a"=>1, "b"=>2, "c"=>3)
+        rev_keys = String[]
+        rev_vals = Int[]
+        for (k,v) in Iterators.reverse(od)
+            push!(rev_keys,k)
+            push!(rev_vals,v)
+        end
+        @test rev_keys == ["c","b","a"]
+        @test rev_vals == [3,2,1]
     end
 end # @testset OrderedDict

--- a/test/test_ordered_set.jl
+++ b/test/test_ordered_set.jl
@@ -259,4 +259,13 @@ using OrderedCollections, Test
         @test issorted(ox; rev=true)
     end
 
+    @testset "lazy reverse iteration" begin
+        ks = collect('a':'z')
+        os  = OrderedSet(ks)
+        pass = true
+        for (n,k) in enumerate(Iterators.reverse(os))
+            pass &= reverse(ks)[n] == k
+        end
+        @test pass
+    end
 end # @testset OrderedSet


### PR DESCRIPTION
I sometimes need to iterate over an ordered dict in reverse order

```julia
od = OrderedDict("a"=>1, "b"=>2, "c"=>3)
for (k,v) in Iterators.reverse(od)
    # do something
end
```

This `PR` adds some support for that by mimicking the `iterate` method. 