### PR TITLE
remove deprecations incl `sort!` piracy, bump version to 2.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OrderedCollections"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-version = "1.6.2"
+version = "2.0.0"
 
 [compat]
 julia = "1.6"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 OrderedCollections.jl
 =====================
 
-Note: v2.0 removes deprecations present in v1.6.2 (for `sort!(::Dict)` and `similar(::Union{OrderedDict, OrderedSet})`), but is otherwise identical.
+Note: v2.0 removes deprecations present in v1.6.2 (for `sort!(::Dict)`, `similar(::Union{OrderedDict, OrderedSet})`, indexing, and `convert` from non-ordered types), but is otherwise identical.
 
 This package implements OrderedDicts and OrderedSets, which are similar to containers in base Julia.
 However, during iteration the Ordered* containers return items in the order in which they were added to the collection.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 OrderedCollections.jl
 =====================
 
+Note: v2.0 removes deprecations present in v1.6.2 (for `sort!(::Dict)` and `similar(::Union{OrderedDict, OrderedSet})`), but is otherwise identical.
+
 This package implements OrderedDicts and OrderedSets, which are similar to containers in base Julia.
 However, during iteration the Ordered* containers return items in the order in which they were added to the collection.
 It also implements `LittleDict` which is a ordered dictionary, that is much faster than any other `AbstractDict` (ordered or not) for small collections.

--- a/src/OrderedCollections.jl
+++ b/src/OrderedCollections.jl
@@ -26,7 +26,4 @@ module OrderedCollections
     include("ordered_set.jl")
     include("dict_sorting.jl")
 
-    import Base: similar
-    @deprecate similar(d::OrderedDict) empty(d)
-    @deprecate similar(s::OrderedSet) empty(s)
 end

--- a/src/dict_sorting.jl
+++ b/src/dict_sorting.jl
@@ -33,8 +33,6 @@ end
 
 sort(d::Union{OrderedDict,OrderedSet}; args...) = sort!(copy(d); args...)
 
-@deprecate sort(d::Dict; args...) sort!(OrderedDict(d); args...)
-
 function sort(d::LittleDict; byvalue::Bool=false, args...)
     if byvalue
         p = sortperm(d.vals; args...)
@@ -43,4 +41,3 @@ function sort(d::LittleDict; byvalue::Bool=false, args...)
     end
     return LittleDict(d.keys[p], d.vals[p])
 end
-

--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -100,7 +100,7 @@ isordered(::Type{T}) where {T<:OrderedDict} = true
 function convert(::Type{OrderedDict{K,V}}, d::AbstractDict) where {K,V}
     d isa OrderedDict{K, V} && return d
     if !isordered(typeof(d))
-        Base.depwarn("Conversion to OrderedDict is deprecated for unordered associative containers (in this case, $(typeof(d))). Use an ordered or sorted associative type, such as SortedDict and OrderedDict.", :convert)
+        error("Conversion to OrderedDict is not supported for unordered associative containers (in this case, $(typeof(d))). Use an ordered or sorted associative type, such as SortedDict and OrderedDict.", :convert)
     end
     h = OrderedDict{K,V}()
     for (k,v) in d

--- a/src/ordered_set.jl
+++ b/src/ordered_set.jl
@@ -79,29 +79,3 @@ function hash(s::OrderedSet, h::UInt)
     hash(s.dict.keys, h)
 end
 
-
-# Deprecated functionality, see
-# https://github.com/JuliaCollections/DataStructures.jl/pull/180#issuecomment-400269803
-
-function getindex(s::OrderedSet, i::Int)
-    Base.depwarn("indexing is deprecated for OrderedSet, please rewrite your code to use iteration", :getindex)
-    s.dict.ndel > 0 && rehash!(s.dict)
-    return s.dict.keys[i]
-end
-
-function lastindex(s::OrderedSet)
-    Base.depwarn("indexing is deprecated for OrderedSet, please rewrite your code to use iteration", :lastindex)
-    s.dict.ndel > 0 && rehash!(s.dict)
-    return lastindex(s.dict.keys)
-end
-
-function nextind(::OrderedSet, i::Int)
-    Base.depwarn("indexing is deprecated for OrderedSet, please rewrite your code to use iteration", :lastindex)
-    return i + 1  # Needed on 0.7 to mimic array indexing.
-end
-
-function keys(s::OrderedSet)
-    Base.depwarn("indexing is deprecated for OrderedSet, please rewrite your code to use iteration", :lastindex)
-    s.dict.ndel > 0 && rehash!(s.dict)
-    return 1:length(s)
-end


### PR DESCRIPTION
fixes https://github.com/JuliaCollections/OrderedCollections.jl/issues/25

Breaking changes are painful, especially with 281 dependents, but the piracy is affecting 4k indirect dependent and it seems better to remove this sooner rather than later.

Note [`sort!` was only deprecated in v1.2](https://github.com/JuliaCollections/OrderedCollections.jl/pull/26), so it is indeed semver breaking to remove it.