### PR TITLE
Remove `sort(::Dict)` piracy (as bugfix)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OrderedCollections"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-version = "1.6.2"
+version = "1.6.3"
 
 [compat]
 julia = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OrderedCollections"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-version = "1.6.3"
+version = "1.6.4"
 
 [compat]
 julia = "1.6"

--- a/src/dict_sorting.jl
+++ b/src/dict_sorting.jl
@@ -33,8 +33,6 @@ end
 
 sort(d::Union{OrderedDict,OrderedSet}; args...) = sort!(copy(d); args...)
 
-@deprecate sort(d::Dict; args...) sort!(OrderedDict(d); args...)
-
 function sort(d::LittleDict; byvalue::Bool=false, args...)
     if byvalue
         p = sortperm(d.vals; args...)
@@ -43,4 +41,3 @@ function sort(d::LittleDict; byvalue::Bool=false, args...)
     end
     return LittleDict(d.keys[p], d.vals[p])
 end
-


### PR DESCRIPTION
Fixes #25 

Alternative to #109 - if PkgEval says none of our direct dependents are relying on this deprecated pathway, perhaps we can remove the sort deprecation as a bugfix. (Suggested by @KristofferC).

@maleadt would it be possible to enable nanosoldier on this repo? (per https://github.com/JuliaCI/Nanosoldier.jl#reverse-ci-for-packages).