### PR TITLE
remove `@deprecate` on `Base.Dict` (type piracy)

### DIFF
--- a/src/dict_sorting.jl
+++ b/src/dict_sorting.jl
@@ -33,8 +33,6 @@ end
 
 sort(d::Union{OrderedDict,OrderedSet}; args...) = sort!(copy(d); args...)
 
-@deprecate sort(d::Dict; args...) sort!(OrderedDict(d); args...)
-
 function sort(d::LittleDict; byvalue::Bool=false, args...)
     if byvalue
         p = sortperm(d.vals; args...)


### PR DESCRIPTION
This causes some warnings on 1.10 and some significant issues with sysimages.
It's been also deprecated years ago, so probably safe to remove