### PR TITLE
CI: also test against LTS and nightly

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,8 @@ jobs:
         version:
           - '1.6'
           - '1'
-#          - 'nightly'
+          - 'lts'
+          - 'nightly'
         os:
           - ubuntu-latest
           - macOS-latest


### PR DESCRIPTION
We keep testing against 1.6 as that's the minimal Julia version
still supported by this package (and it seems wise to keep that
supported as long as possible).
