### PR TITLE
Remove convert method to OrderedDict

### DIFF
--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -95,24 +95,6 @@ defined order (such as `OrderedDict` and `SortedDict`), and `false` otherwise.
 isordered(::Type{T}) where {T<:AbstractDict} = false
 isordered(::Type{T}) where {T<:OrderedDict} = true
 
-# conversion between OrderedDict types
-function convert(::Type{OrderedDict{K,V}}, d::AbstractDict) where {K,V}
-    d isa OrderedDict{K, V} && return d
-    if !isordered(typeof(d))
-        Base.depwarn("Conversion to OrderedDict is deprecated for unordered associative containers (in this case, $(typeof(d))). Use an ordered or sorted associative type, such as SortedDict and OrderedDict.", :convert)
-    end
-    h = OrderedDict{K,V}()
-    for (k,v) in d
-        ck = convert(K,k)
-        if !haskey(h,ck)
-            h[ck] = convert(V,v)
-        else
-            error("key collision during dictionary conversion")
-        end
-    end
-    return h
-end
-
 isslotempty(slot_value::Integer) = slot_value == 0
 isslotfilled(slot_value::Integer) = slot_value > 0
 isslotmissing(slot_value::Integer) = slot_value < 0


### PR DESCRIPTION
The generic one in Julia stdlib does the job, except for the deprecation warning shown when converting from an unordered dict (such as `Base.Dict`) to an `OrderedDict{K,V}` type.

This avoids potential invalidations in packages. There also is no explanation as to why it makes sense to forbids such conversions.


The `depwarn` was introduced in bea403157497de7821d824fe44d03f7aff38743e but I don't know why. I certainly don't want to hastily merge this without understanding this better. I am also happy to close this PR and instead open one which adds a comment with an explanation of why this conversion is deprecated, as soon as somebody explains it to me :-). Or just open a PR with that explanation and we merge that and close this PR.

CC @timholy @oxinabox who perhaps might have an idea?

Also I figure one should perhaps use nanosoldier to test a PR like this given how critical this package is in the ecosystem? but I have no idea how to do that (and maybe also not the access rights? as I said, I know nothing about it)