### PR TITLE
Version 1.7.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OrderedCollections"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-version = "1.6.4-DEV"
+version = "1.7.0"
 
 [compat]
 julia = "1.6"


### PR DESCRIPTION
There have been a ton of fixes and improvements since the last release, so we should make a release now.

Any objections or concerns @timholy @oxinabox or anyone else?

There are a couple other open issues that I think are easy enough to fix, but I don't think that's any reason to delay a release?


Draft of release notes for JuliaRegistrator bot:

----

Release notes:

## New features

- Add `sort!` method for unfrozen `LittleDict` ([#136](https://github.com/JuliaCollections/OrderedCollections.jl/pull/136))
- Add `mergewith` method for `LittleDict` ([#119](https://github.com/JuliaCollections/OrderedCollections.jl/pull/119))

## Bug fixes
- Fix `rehash!` for `OrderedDict` (for example `delete!(d, nothing)` could produce nonsense or even crash) ([#120](https://github.com/JuliaCollections/OrderedCollections.jl/pull/120))
- Avoid iterating twice over generators when there is an exception, at least in Julia >= 1.11 ([#137](https://github.com/JuliaCollections/OrderedCollections.jl/pull/137))
 
## Other changes
- Remove all uses `ccall` ([#121](https://github.com/JuliaCollections/OrderedCollections.jl/pull/121))
- Remove `convert` method for `Type{OrderedDict}`, the generic Julia method does the same, except for a deprecation warning our method produced ([#139](https://github.com/JuliaCollections/OrderedCollections.jl/pull/139))
- Several other janitorial changes
