### PR TITLE
Change pop! for LittleDict behavior

### DIFF
--- a/src/little_dict.jl
+++ b/src/little_dict.jl
@@ -241,7 +241,7 @@ function Base.pop!(dd::UnfrozenLittleDict)
     return pop!(dd.vals)
 end
 
-function Base.pop!(dd::UnfrozenLittleDict, key)
+function _pop!(dd::UnfrozenLittleDict, key, default=NotFoundSentinel())
     @assert length(dd.keys) == length(dd.vals)
 
     for ii in 1:length(dd.keys)
@@ -253,10 +253,17 @@ function Base.pop!(dd::UnfrozenLittleDict, key)
             return val
         end
     end
+
+    return default
+end
+
+function Base.pop!(dd::UnfrozenLittleDict, key, default=NotFoundSentinel())
+    val = _pop!(dd, key, default)
+    return val === NotFoundSentinel() ? throw(KeyError(key)) : val
 end
 
 function Base.delete!(dd::UnfrozenLittleDict, key)
-    pop!(dd, key)
+    _pop!(dd, key)
     return dd
 end
 

--- a/test/test_little_dict.jl
+++ b/test/test_little_dict.jl
@@ -139,6 +139,48 @@ using OrderedCollections: FrozenLittleDict, UnfrozenLittleDict
         @test od60[14] == 15
     end
 
+    @testset "pop!" begin
+        @testset "key" begin
+            expected = "bar"
+            ld = LittleDict("foo"=>expected)
+            ret = pop!(ld, "foo")
+
+            @test ret == expected
+        end
+
+        @testset "key dne" begin
+            @test_throws KeyError pop!(LittleDict(), "foo")
+        end
+
+        @testset "key -- default" begin
+            expected = "bar"
+            ld = LittleDict("foo"=>expected)
+            ret = pop!(ld, "foo", "baz")
+
+            @test ret == expected
+        end
+
+        @testset "key dne -- default" begin
+            expected = "baz"
+            ret = pop!(LittleDict(), "foo", expected)
+
+            @test ret == expected
+        end
+    end
+
+    @testset "delete!" begin
+        @testset "key" begin
+            ld = LittleDict("foo"=>"bar")
+            ret = delete!(ld, "foo")
+
+            @test ret == LittleDict()
+        end
+
+        @testset "key dne" begin
+            @test delete!(LittleDict(), "foo") == LittleDict()
+        end
+    end
+
 
     ##############################
     # Copied and modified from Base/test/dict.jl


### PR DESCRIPTION
- now there is a 'default' argument just like for Dict
- if no default is provided and the key is not found it now throws an error as specified in the `pop!` docstring and also matching what `Dict` and `OrderedDict` do. If anyone needs to adjust existing code that relies on `pop!` not throwing, they can either provide a `default` value, or use `delete!` (which returns the dictionary and does not throw if the key is not present).

Closely based on PR #59 with a few minor tweaks.

Resolves #61

But beware, this may break some existing code, so I am marking it as "breaking" and putting it onto the 2.0.0 milestone.