### PR TITLE
`LittleDict` constructor from `AbstractDict`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OrderedCollections"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-version = "1.8.0"
+version = "1.8.1"
 
 [compat]
 julia = "1.7.1"

--- a/src/little_dict.jl
+++ b/src/little_dict.jl
@@ -45,6 +45,7 @@ struct LittleDict{K, V, KS<:StoreType{K}, VS<:StoreType{V}} <: AbstractDict{K, V
     LittleDict{K, V, <:Tuple, <:Tuple}() where {K, V} = new{K, V, Tuple{}, Tuple{}}((), ())
     LittleDict{K, V, KS, VS}() where {K, V, KS, VS} = LittleDict{K, V, KS, VS}(KS(), VS())
 end
+LittleDict{K, V, KS, VS}(d::AbstractDict) where {K, V, KS<:StoreType{K}, VS<:StoreType{V}} = LittleDict{K, V, KS, VS}(collect(keys(d)), collect(values(d)))
 
 function LittleDict{K,V}(ks::KS, vs::VS) where {K,V, KS<:StoreType,VS<:StoreType}
     return LittleDict{K, V, KS, VS}(ks, vs)

--- a/test/test_little_dict.jl
+++ b/test/test_little_dict.jl
@@ -119,6 +119,10 @@ using OrderedCollections: FrozenLittleDict, UnfrozenLittleDict
         @test valtype(dc) == Float64
         @test keys(dc) == keys(d)
         @test collect(values(dc)) == collect(values(d))
+
+        d = Dict(i=>Float32(i) for i = 1:10)
+        @test convert(LittleDict{Int,Float32}, d) isa LittleDict{Int,Float32}
+        @test convert(LittleDict{Int,Float32,Vector{Int},Vector{Float32}}, d) isa LittleDict{Int,Float32,Vector{Int},Vector{Float32}}
     end
 
     @testset "Issue #60" begin


### PR DESCRIPTION
Formerly, statements like `convert(typeof(ld), d)` would fail if
`ld` was a `LittleDict` and `d` was an `AbstractDict`.