### PR TITLE
`issorted(ld; byvalue=true)` for LittleDicts

### DIFF
--- a/src/dict_sorting.jl
+++ b/src/dict_sorting.jl
@@ -1,5 +1,5 @@
 # Sort for dicts
-import Base: sort, sort!
+import Base: sort, sort!, issorted
 
 function sort!(d::OrderedDict; byvalue::Bool=false, args...)
     if d.ndel > 0
@@ -55,3 +55,10 @@ function sort(d::LittleDict; byvalue::Bool=false, args...)
     return LittleDict(d.keys[p], d.vals[p])
 end
 
+function issorted(d::LittleDict; byvalue::Bool=false, args...)
+    if byvalue
+        return issorted(d.vals; args...)
+    else
+        return issorted(d.keys; args...)
+    end
+end

--- a/test/test_little_dict.jl
+++ b/test/test_little_dict.jl
@@ -504,7 +504,9 @@ using OrderedCollections: FrozenLittleDict, UnfrozenLittleDict
         @test collect(values(sd)) == collect('z':-1:'q')
         @test sort(sd) == sd
 
+        @test !issorted(d; byvalue=true)
         sdv = sort(d; byvalue=true)
+        @test issorted(sdv; byvalue=true)
         @test collect(keys(d)) == ks    # verify d is not changed by sort()
         @test collect(keys(sdv)) == 10:-1:1
         @test collect(values(sdv)) == collect('q':'z')


### PR DESCRIPTION
Since `byvalue` is a keyword for `sort`, we should support it for
`issorted`. Otherwise, you can't check whether a LittleDict is sorted
for generic kwargs, or without diving into internals.