### PR TITLE
Add `Integer` type annotation to `sizehint!` overloads

### DIFF
--- a/src/little_dict.jl
+++ b/src/little_dict.jl
@@ -196,7 +196,7 @@ end
 
 ######## Methods that all mutable AbstractDict's should implement
 
-function Base.sizehint!(dd::UnfrozenLittleDict, sz)
+function Base.sizehint!(dd::UnfrozenLittleDict, sz::Integer)
     sizehint!(dd.keys, sz)
     sizehint!(dd.vals,sz)
     return dd

--- a/src/little_set.jl
+++ b/src/little_set.jl
@@ -111,7 +111,7 @@ function Base.copymutable(s::LittleSet{T}) where {T}
     LittleSet{T}(new_data)
 end
 
-function Base.sizehint!(s::UnfrozenLittleSet, sz)
+function Base.sizehint!(s::UnfrozenLittleSet, sz::Integer)
     sizehint!(getfield(s, :data), sz)
     return s
 end

--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -212,7 +212,7 @@ function rehash!(h::OrderedDict{K,V}, newsz::Integer = length(h.slots)) where {K
     return h
 end
 
-function sizehint!(d::OrderedDict, newsz)
+function sizehint!(d::OrderedDict, newsz::Integer)
     slotsz = (newsz*3)>>1
     oldsz = length(d.slots)
     if slotsz <= oldsz


### PR DESCRIPTION
JuliaLang/julia#59168 changed the base signature of `sizehint` to use `::Integer` instead of `::Any` for the second argument, thus packages also overload against the signature instead in order to avoid method ambiguity error.