### PR TITLE
Delete unnecessary `convert()` method for OrderedDict

### DIFF
--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -100,24 +100,6 @@ defined order (such as `OrderedDict` and `SortedDict`), and `false` otherwise.
 isordered(::Type{T}) where {T<:AbstractDict} = false
 isordered(::Type{T}) where {T<:OrderedDict} = true
 
-# conversion between OrderedDict types
-function convert(::Type{OrderedDict{K,V}}, d::AbstractDict) where {K,V}
-    d isa OrderedDict{K, V} && return d
-    if !isordered(typeof(d))
-        Base.depwarn("Conversion to OrderedDict is deprecated for unordered associative containers (in this case, $(typeof(d))). Use an ordered or sorted associative type, such as SortedDict and OrderedDict.", :convert)
-    end
-    h = OrderedDict{K,V}()
-    for (k,v) in d
-        ck = convert(K,k)
-        if !haskey(h,ck)
-            h[ck] = convert(V,v)
-        else
-            error("key collision during dictionary conversion")
-        end
-    end
-    return h
-end
-
 isslotempty(slot_value::Integer) = slot_value == 0
 isslotfilled(slot_value::Integer) = slot_value > 0
 isslotmissing(slot_value::Integer) = slot_value < 0


### PR DESCRIPTION
This causes invalidations and already has a definition in Base: https://github.com/JuliaLang/julia/blob/8c145c1e0e4676ce57a32d7125cae05a2ece3ac6/base/abstractdict.jl#L577

Fixes these invalidations:
```julia
 inserting convert(::Type{OrderedCollections.OrderedDict{K, V}}, d::AbstractDict) where {K, V} @ OrderedCollections ~/.julia/packages/OrderedCollections/Xihhq/src/ordered_dict.jl:104 invalidated:                                            
   backedges: 1: superseding convert(::Type{T}, x::T) where T<:AbstractDict @ Base abstractdict.jl:575 with MethodInstance for convert(::Type{T}, ::T) where T<:AbstractDict (3 children)                                                      
              2: superseding convert(::Type{T}, x::AbstractDict) where T<:AbstractDict @ Base abstractdict.jl:577 with MethodInstance for convert(::Type{<:AbstractDict}, ::AbstractDict) (470 children)                                       
```

The original loop seems to be quite old so I don't think we'll miss anything by removing it. Would it be possible to make a release with this?