### PR TITLE
Remove deprecations for v2.0 release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OrderedCollections"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-version = "1.8.2"
+version = "2.0.0"
 
 [compat]
 julia = "1.7.1"

--- a/src/OrderedCollections.jl
+++ b/src/OrderedCollections.jl
@@ -26,8 +26,4 @@ module OrderedCollections
     include("little_set.jl")
     include("ordered_set.jl")
     include("dict_sorting.jl")
-
-    import Base: similar
-    @deprecate similar(d::OrderedDict) empty(d)
-    @deprecate similar(s::OrderedSet) empty(s)
 end

--- a/src/dict_sorting.jl
+++ b/src/dict_sorting.jl
@@ -44,8 +44,6 @@ end
 
 sort(d::Union{OrderedDict,OrderedSet}; args...) = sort!(copy(d); args...)
 
-@deprecate sort(d::Dict; args...) sort!(OrderedDict(d); args...)
-
 function sort(d::LittleDict; byvalue::Bool=false, args...)
     if byvalue
         p = sortperm(d.vals; args...)

--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -104,7 +104,7 @@ isordered(::Type{T}) where {T<:OrderedDict} = true
 function convert(::Type{OrderedDict{K,V}}, d::AbstractDict) where {K,V}
     d isa OrderedDict{K, V} && return d
     if !isordered(typeof(d))
-        Base.depwarn("Conversion to OrderedDict is deprecated for unordered associative containers (in this case, $(typeof(d))). Use an ordered or sorted associative type, such as SortedDict and OrderedDict.", :convert)
+        throw(ArgumentError("Cannot convert unordered `AbstractDict`s into `OrderedDicts`"))
     end
     h = OrderedDict{K,V}()
     for (k,v) in d

--- a/src/ordered_set.jl
+++ b/src/ordered_set.jl
@@ -89,29 +89,3 @@ function hash(s::OrderedSet, h::UInt)
     s.dict.ndel > 0 && rehash!(s.dict)
     hash(s.dict.keys, h)
 end
-
-# Deprecated functionality, see
-# https://github.com/JuliaCollections/DataStructures.jl/pull/180#issuecomment-400269803
-
-function getindex(s::OrderedSet, i::Int)
-    Base.depwarn("indexing is deprecated for OrderedSet, please rewrite your code to use iteration", :getindex)
-    s.dict.ndel > 0 && rehash!(s.dict)
-    return s.dict.keys[i]
-end
-
-function lastindex(s::OrderedSet)
-    Base.depwarn("indexing is deprecated for OrderedSet, please rewrite your code to use iteration", :lastindex)
-    s.dict.ndel > 0 && rehash!(s.dict)
-    return lastindex(s.dict.keys)
-end
-
-function nextind(::OrderedSet, i::Int)
-    Base.depwarn("indexing is deprecated for OrderedSet, please rewrite your code to use iteration", :lastindex)
-    return i + 1  # Needed on 0.7 to mimic array indexing.
-end
-
-function keys(s::OrderedSet)
-    Base.depwarn("indexing is deprecated for OrderedSet, please rewrite your code to use iteration", :lastindex)
-    s.dict.ndel > 0 && rehash!(s.dict)
-    return 1:length(s)
-end


### PR DESCRIPTION
Its been almost 12 months since last release.
So I don't think any more deprecations any time soon.
and most of these deprecations are years and years old.
So hopefully are long gone from anyone's code bases.

This notably will close #25 

### Change log:

v2 is only removal of long standing depreactions.
If you are using v1.8.1 already 
and you can run your code with `--depwarn=error` then there is nothing to change.

Remnoved deprated functionality:

 - type-piratical: `sort(d::Dict; args...)` which previously returned an `OrderedDict` (https://github.com/JuliaCollections/OrderedCollections.jl/issues/25)
 - ability to `convert `unordered dicts into `OrderedDict`s
 - indexing into `OrderedSet`s (https://github.com/JuliaCollections/DataStructures.jl/pull/180#issuecomment-400269803)
 - constructing new empty `OrderedSet`s and `OrderedDict`s via empty.