### PR TITLE
Swiss table OrderedDict

### DIFF
--- a/src/dict_support.jl
+++ b/src/dict_support.jl
@@ -1,10 +1,5 @@
 # support functions
 
-# _tablesz and hashindex are defined in Base, but are not exported,
-# so they are redefined here.
-_tablesz(x::Integer) = x < 16 ? 16 : one(x)<<((sizeof(x)<<3)-leading_zeros(x-1))
-hashindex(key, sz) = (reinterpret(Int,(hash(key))) & (sz-1)) + 1
-
 const orderedset_seed = UInt === UInt64 ? 0x2114638a942a91a5 : 0xd86bdbf1
 
 struct NotFoundSentinel end  # Struct to mark not not found

--- a/src/dict_support.jl
+++ b/src/dict_support.jl
@@ -8,3 +8,7 @@ hashindex(key, sz) = (reinterpret(Int,(hash(key))) & (sz-1)) + 1
 const orderedset_seed = UInt === UInt64 ? 0x2114638a942a91a5 : 0xd86bdbf1
 
 struct NotFoundSentinel end  # Struct to mark not not found
+
+@static if VERSION < v"1.11"
+    const Memory = Vector
+end

--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -1,8 +1,80 @@
 using Base: isbitsunion
 
-# These can be changed, to trade off better performance for space
-const global maxallowedprobe = isdefined(Base, :maxallowedprobe) ? Base.maxallowedprobe : 16
-const global maxprobeshift   = isdefined(Base, :maxprobeshift) ? Base.maxprobeshift : 6
+# ---------------------------------------------------------------------------
+# Swiss-table primitives
+# ---------------------------------------------------------------------------
+
+@inline function split_hash(key)
+    h = hash(key) % UInt
+    h2 = UInt8((h >> (8 * sizeof(UInt) - 7)) & 0x7F)
+    return h, h2
+end
+
+@inline group_for(h1::UInt, ngroups::Int) =
+    Int(h1 & (UInt(ngroups) - UInt(1))) + 1
+
+@inline slot_in_group(g_idx::Int, bit::Int) = (g_idx - 1) * 16 + bit + 1
+
+@inline next_group_idx(g_idx::Int, step::Int, ngroups::Int) =
+    Int((UInt(g_idx - 1) + UInt(step)) & (UInt(ngroups) - UInt(1))) + 1
+
+# 16-byte SIMD vector type for the llvmcall helpers below.
+const _Vec16u8 = NTuple{16, VecElement{UInt8}}
+
+@inline _to_vec(g::NTuple{16,UInt8}) =
+    ntuple(i -> VecElement(@inbounds g[i]), Val(16))
+
+# Generic LLVM movemask: compare 16 bytes, bitcast i1-vector to i16.
+# LLVM lowers this to pmovmskb on x86 and equivalent NEON on aarch64.
+@inline function _eq_movemask(g::_Vec16u8, t::_Vec16u8)
+    Base.llvmcall(
+        """
+        %cmp = icmp eq <16 x i8> %0, %1
+        %mask = bitcast <16 x i1> %cmp to i16
+        ret i16 %mask
+        """,
+        UInt16, Tuple{_Vec16u8, _Vec16u8}, g, t,
+    )
+end
+
+# High-bit movemask: each byte's MSB → corresponding bit in UInt16.
+# `icmp slt ... 0` treats the byte as signed for the test — signedness is
+# per-instruction, not per-type, so the UInt8 vector arg is fine.
+@inline function _high_bit_movemask(g::_Vec16u8)
+    Base.llvmcall(
+        """
+        %cmp = icmp slt <16 x i8> %0, zeroinitializer
+        %mask = bitcast <16 x i1> %cmp to i16
+        ret i16 %mask
+        """,
+        UInt16, Tuple{_Vec16u8}, g,
+    )
+end
+
+@inline function match_byte(g::NTuple{16,UInt8}, target::UInt8)
+    gv = _to_vec(g)
+    tv = ntuple(_ -> VecElement(target), Val(16))
+    return _eq_movemask(gv, tv)
+end
+
+@inline match_empty_or_deleted(g::NTuple{16,UInt8}) = _high_bit_movemask(_to_vec(g))
+
+# Control-byte sentinels. A full slot stores the 7-bit h2 fingerprint
+# (0x00..0x7F); the high bit is reserved for these two sentinels.
+const CTRL_EMPTY   = 0x80
+const CTRL_DELETED = 0xFE
+
+const _empty_group = ntuple(_ -> CTRL_EMPTY, Val(16))
+
+@inline load_group(ctrl::Memory{NTuple{16,UInt8}}, g_idx::Int) =
+    @inbounds ctrl[g_idx]
+
+@inline function set_ctrl_byte!(ctrl::Memory{NTuple{16,UInt8}}, slot::Int, byte::UInt8)
+    g_idx = ((slot - 1) >> 4) + 1
+    bit = ((slot - 1) & 15) + 1
+    @inbounds ctrl[g_idx] = Base.setindex(ctrl[g_idx], byte, bit)
+    return
+end
 
 """
     OrderedDict
@@ -11,16 +83,24 @@ const global maxprobeshift   = isdefined(Base, :maxprobeshift) ? Base.maxprobesh
 refers to insertion order, which allows deterministic iteration over the dictionary.
 """
 mutable struct OrderedDict{K,V} <: AbstractDict{K,V}
-    slots::Vector{Int32}
+    ctrl::Memory{NTuple{16,UInt8}}
+    idx::Memory{Int32}
     keys::Vector{K}
     vals::Vector{V}
     ndel::Int
-    maxprobe::Int
     dirty::Bool
 end
 
 function OrderedDict{K,V}() where {K,V}
-    OrderedDict{K,V}(zeros(Int32,16), Vector{K}(), Vector{V}(), 0, 0, false)
+    OrderedDict{K,V}(Memory{NTuple{16,UInt8}}(undef, 0), Memory{Int32}(undef, 0),
+                     Vector{K}(), Vector{V}(), 0, false)
+end
+
+@inline _current_nslots(h::OrderedDict) = length(h.ctrl) << 4
+
+@inline function _round_table_size(n::Integer)
+    n <= 0 && return 0
+    return max(16, 1 << (8*sizeof(Int) - leading_zeros(Int(n) - 1)))
 end
 
 function OrderedDict{K,V}(kv) where {K,V}
@@ -43,11 +123,9 @@ function OrderedDict{K,V}(ps::Pair...) where {K,V}
 end
 
 function OrderedDict{K,V}(d::OrderedDict{K,V}) where {K,V}
-    if d.ndel > 0
-        rehash!(d)
-    end
+    d.ndel > 0 && rehash!(d)
     @assert d.ndel == 0
-    OrderedDict{K,V}(copy(d.slots), copy(d.keys), copy(d.vals), 0, d.maxprobe, false)
+    OrderedDict{K,V}(copy(d.ctrl), copy(d.idx), copy(d.keys), copy(d.vals), 0, false)
 end
 
 OrderedDict() = OrderedDict{Any,Any}()
@@ -118,116 +196,91 @@ function convert(::Type{OrderedDict{K,V}}, d::AbstractDict) where {K,V}
     return h
 end
 
-isslotempty(slot_value::Integer) = slot_value == 0
-isslotfilled(slot_value::Integer) = slot_value > 0
-isslotmissing(slot_value::Integer) = slot_value < 0
+function insert_fresh!(ctrl::Memory{NTuple{16,UInt8}}, idx::Memory{Int32}, key,
+                       pos::Int32, ngroups::Int)
+    h1, h2 = split_hash(key)
+    g_idx = group_for(h1, ngroups)
+    step = 1
+    while true
+        g = load_group(ctrl, g_idx)
+        m = match_byte(g, CTRL_EMPTY)
+        if m != 0
+            bit = trailing_zeros(m)
+            slot = slot_in_group(g_idx, bit)
+            set_ctrl_byte!(ctrl, slot, h2)
+            @inbounds idx[slot] = pos
+            return
+        end
+        g_idx = next_group_idx(g_idx, step, ngroups)
+        step += 1
+    end
+end
 
-function rehash!(h::OrderedDict{K,V}, newsz::Integer = length(h.slots)) where {K,V}
-    olds = h.slots
-    keys = h.keys
-    vals = h.vals
-    sz = length(olds)
-    newsz = _tablesz(newsz)
+function rehash!(h::OrderedDict{K,V}, newsz::Integer = _current_nslots(h)) where {K,V}
     h.dirty = true
+    newsz = _round_table_size(newsz)
+    ngroups = newsz >> 4
+    new_ctrl = Memory{NTuple{16,UInt8}}(undef, ngroups)
+    new_idx  = Memory{Int32}(undef, newsz)
+    fill!(new_ctrl, _empty_group)
+
     count0 = length(h)
     if count0 == 0
-        resize!(h.slots, newsz)
-        fill!(h.slots, 0)
-        resize!(h.keys, 0)
-        resize!(h.vals, 0)
+        empty!(h.keys)
+        empty!(h.vals)
         h.ndel = 0
-        return h
-    end
-
-    slots = zeros(Int32, newsz)
-    maxprobe = 0
-
-    if h.ndel > 0
-        ndel0 = h.ndel
-        ptrs = !isbitstype(K) && !isbitsunion(K)
-        to = 1
-        # TODO: to get the best performance we need to avoid reallocating these.
-        # This algorithm actually works in place, unless the dict is modified
-        # due to GC during this process.
-        newkeys = similar(keys, count0)
-        newvals = similar(vals, count0)
-        @inbounds for from = 1:length(keys)
-            if !ptrs || isassigned(keys, from)
-                k = keys[from]
-                hashk = hash(k)%Int
-                isdeleted = false
-                if !ptrs
-                    iter = 0
-                    index = (hashk & (sz-1)) + 1
-                    while iter <= h.maxprobe
-                        si = olds[index]
-                        si == from && break
-                        # if we find si == 0, then the key was deleted and it's slot was reused/overwritten
-                        (si == -from || si == 0) && (isdeleted = true; break)
-                        index = (index & (sz-1)) + 1
-                        iter += 1
-                    end
-                    iter > h.maxprobe && (isdeleted = true)  # Another case where the slot was reused/overwritten
-                end
-                if !isdeleted
-                    index0 = index = (hashk & (newsz-1)) + 1
-                    while slots[index] != 0
-                        index = (index & (newsz-1)) + 1
-                    end
-                    probe = (index - index0) & (newsz-1)
-                    probe > maxprobe && (maxprobe = probe)
-                    slots[index] = to
-                    newkeys[to] = k
-                    newvals[to] = vals[from]
-                    to += 1
-                end
-                if h.ndel != ndel0
-                    # if items are removed by finalizers, retry
-                    return rehash!(h, newsz)
-                end
+    elseif h.ndel == 0
+        # All entries live: rebuild ctrl/idx, leave keys/vals in place.
+        @inbounds for i in 1:count0
+            insert_fresh!(new_ctrl, new_idx, h.keys[i], Int32(i), ngroups)
+        end
+    else
+        # Build a bitmap of live keys-positions by walking ctrl, then migrate.
+        old_ctrl = h.ctrl
+        old_idx = h.idx
+        live = falses(length(h.keys))
+        @inbounds for og in 1:length(old_ctrl)
+            g = load_group(old_ctrl, og)
+            m_full = (~match_empty_or_deleted(g)) & 0xFFFF
+            while m_full != 0
+                bit = trailing_zeros(m_full)
+                live[old_idx[slot_in_group(og, bit)]] = true
+                m_full &= m_full - UInt16(1)
             end
+        end
+
+        newkeys = similar(h.keys, count0)
+        newvals = similar(h.vals, count0)
+        to = 1
+        @inbounds for from in 1:length(h.keys)
+            live[from] || continue
+            k = h.keys[from]
+            insert_fresh!(new_ctrl, new_idx, k, Int32(to), ngroups)
+            newkeys[to] = k
+            newvals[to] = h.vals[from]
+            to += 1
         end
         h.keys = newkeys
         h.vals = newvals
         h.ndel = 0
-    else
-        @inbounds for i = 1:count0
-            k = keys[i]
-            index0 = index = hashindex(k, newsz)
-            while slots[index] != 0
-                index = (index & (newsz-1)) + 1
-            end
-            probe = (index - index0) & (newsz-1)
-            probe > maxprobe && (maxprobe = probe)
-            slots[index] = i
-            if h.ndel > 0
-                # if items are removed by finalizers, retry
-                return rehash!(h, newsz)
-            end
-        end
     end
 
-    h.slots = slots
-    h.maxprobe = maxprobe
+    h.ctrl = new_ctrl
+    h.idx  = new_idx
     return h
 end
 
 function sizehint!(d::OrderedDict, newsz::Integer)
-    slotsz = (newsz*3)>>1
-    oldsz = length(d.slots)
-    if slotsz <= oldsz
-        # todo: shrink
-        # be careful: rehash!() assumes everything fits. it was only designed
-        # for growing.
-        return d
-    end
-    # grow at least 25%
-    slotsz = max(slotsz, (oldsz*5)>>2)
-    rehash!(d, slotsz)
+    needed = (Int(newsz) * 8 + 6) ÷ 7
+    target = _round_table_size(needed)
+    target > _current_nslots(d) && rehash!(d, target)
+    return d
 end
 
 function empty!(h::OrderedDict{K,V}) where {K,V}
-    fill!(h.slots, 0)
+    if length(h.ctrl) > 0
+        fill!(h.ctrl, _empty_group)
+    end
     empty!(h.keys)
     empty!(h.vals)
     h.ndel = 0
@@ -235,92 +288,115 @@ function empty!(h::OrderedDict{K,V}) where {K,V}
     return h
 end
 
-# get the index where a key is stored, or -1 if not present
-function ht_keyindex(h::OrderedDict{K,V}, key, direct) where {K,V}
-    slots = h.slots
-    sz = length(slots)
-    iter = 0
-    maxprobe = h.maxprobe
-    index = hashindex(key, sz)
-    keys = h.keys
-
-    @inbounds while true
-        si = slots[index]
-        isslotempty(si) && break
-        if isslotfilled(si) && isequal(key, keys[si])
-            return ifelse(direct, oftype(index, si), index)
+# Find `key` (with fingerprint `h2`) in a single group `g`. Returns the slot
+# index (>0) on hit, 0 on miss. `g_zero` is (g_idx - 1) — its pre-decremented
+# form lets the single-group fast path skip any group arithmetic.
+@inline function _find_h2_in_group(g::NTuple{16,UInt8}, g_zero::Int,
+                                   idx::Memory{Int32}, keys::Vector,
+                                   key, h2::UInt8)
+    m = match_byte(g, h2)
+    @inbounds while m != 0
+        bit = trailing_zeros(m)
+        slot = g_zero * 16 + bit + 1
+        i = idx[slot]
+        if isequal(key, keys[i])
+            return slot
         end
-
-        index = (index & (sz-1)) + 1
-        iter += 1
-        iter > maxprobe && break
+        m &= m - UInt16(1)
     end
-
-    return -1
+    return 0
 end
 
-# get the index where a key is stored, or -pos if not present
-# and the key would be inserted at pos
-# This version is for use by setindex! and get!
-function ht_keyindex2(h::OrderedDict{K,V}, key) where {K,V}
-    slots = h.slots
-    sz = length(slots)
-    iter = 0
-    maxprobe = h.maxprobe
-    index = hashindex(key, sz)
+function ht_keyindex(h::OrderedDict{K,V}, key, direct::Bool) where {K,V}
+    nctrl = length(h.ctrl)
+    nctrl == 0 && return -1
+    ctrl = h.ctrl
+    idx = h.idx
     keys = h.keys
-    avail = 0
+    h1, h2 = split_hash(key)
 
+    if nctrl == 1
+        # Single-group fast path: no probing, group is always ctrl[1].
+        @inbounds g = ctrl[1]
+        slot = _find_h2_in_group(g, 0, idx, keys, key, h2)
+        slot != 0 && return direct ? Int(@inbounds idx[slot]) : slot
+        return -1
+    end
+
+    ngroups = nctrl
+    g_idx = group_for(h1, ngroups)
+    step = 1
     @inbounds while true
-        si = slots[index]
-        if isslotempty(si)
-            avail < 0 && return avail
-            return -index
-        end
-
-        if isslotmissing(si)
-            avail == 0 && (avail = -index)
-        elseif key === keys[si] || isequal(key, keys[si])
-            return oftype(index, si)
-        end
-
-        index = (index & (sz-1)) + 1
-        iter += 1
-        iter > maxprobe && break
+        g = load_group(ctrl, g_idx)
+        slot = _find_h2_in_group(g, g_idx - 1, idx, keys, key, h2)
+        slot != 0 && return direct ? Int(idx[slot]) : slot
+        match_byte(g, CTRL_EMPTY) != 0 && return -1
+        g_idx = next_group_idx(g_idx, step, ngroups)
+        step += 1
     end
-
-    avail < 0 && return avail
-
-    # If key is not present, may need to keep searching to find slot
-    maxallowed = max(maxallowedprobe, sz>>maxprobeshift)
-    @inbounds while iter < maxallowed
-        if !isslotfilled(slots[index])
-            h.maxprobe = iter
-            return -index
-        end
-        index = (index & (sz-1)) + 1
-        iter += 1
-    end
-
-    rehash!(h, length(h) > 64000 ? sz*2 : sz*4)
-
-    return ht_keyindex2(h, key)
 end
 
-function _setindex!(h::OrderedDict, v, key, index)
-    hk, hv = h.keys, h.vals
-    push!(hk, key)
-    push!(hv, v)
-    nk = length(hk)
-    @inbounds h.slots[index] = nk
+function ht_keyindex2_h(h::OrderedDict{K,V}, key, h1::UInt, h2::UInt8) where {K,V}
+    nctrl = length(h.ctrl)
+    ctrl = h.ctrl
+    idx = h.idx
+    keys = h.keys
+
+    if nctrl == 1
+        # Single-group fast path. We're guaranteed at least one empty-or-deleted
+        # byte (load factor invariant), so the insert slot always exists.
+        @inbounds g = ctrl[1]
+        slot = _find_h2_in_group(g, 0, idx, keys, key, h2)
+        slot != 0 && return Int(@inbounds idx[slot])
+        me = match_empty_or_deleted(g)
+        return -(trailing_zeros(me) + 1)
+    end
+
+    ngroups = nctrl
+    g_idx = group_for(h1, ngroups)
+    step = 1
+    insert_slot = 0
+
+    @inbounds while true
+        g = load_group(ctrl, g_idx)
+        slot = _find_h2_in_group(g, g_idx - 1, idx, keys, key, h2)
+        slot != 0 && return Int(idx[slot])
+
+        if insert_slot == 0
+            me = match_empty_or_deleted(g)
+            if me != 0
+                bit = trailing_zeros(me)
+                insert_slot = slot_in_group(g_idx, bit)
+            end
+        end
+
+        match_byte(g, CTRL_EMPTY) != 0 && return -insert_slot
+
+        g_idx = next_group_idx(g_idx, step, ngroups)
+        step += 1
+    end
+end
+
+function _setindex!(h::OrderedDict, v, key, slot, h2::UInt8)
+    push!(h.keys, key)
+    push!(h.vals, v)
+    nk = length(h.keys)
+    @assert nk <= typemax(Int32) "OrderedDict cannot exceed $(typemax(Int32)) total inserts"
+    set_ctrl_byte!(h.ctrl, slot, h2)
+    @inbounds h.idx[slot] = Int32(nk)
     h.dirty = true
+    maybe_rehash!(h)
+end
 
-    sz = length(h.slots)
-    cnt = nk - h.ndel
-    # Rehash now if necessary
-    if h.ndel >= ((3*nk)>>2) > 4 || cnt*3 > sz*2
-        # > 3/4 deleted or > 2/3 full
-        rehash!(h, cnt > 64000 ? cnt*2 : cnt*4)
+function maybe_rehash!(h::OrderedDict)
+    nslots = _current_nslots(h)
+    nk = length(h.keys)
+    if 8 * nk >= 7 * nslots
+        if 4 * h.ndel > nslots
+            rehash!(h, nslots)
+        else
+            rehash!(h, max(2 * nslots, 16))
+        end
     end
 end
 
@@ -331,15 +407,16 @@ function setindex!(h::OrderedDict{K,V}, v0, key0) where {K,V}
     end
     v = convert(V, v0)
 
-    index = ht_keyindex2(h, key)
+    length(h.ctrl) == 0 && rehash!(h, 16)
 
+    h1, h2 = split_hash(key)
+    index = ht_keyindex2_h(h, key, h1, h2)
     if index > 0
         @inbounds h.keys[index] = key
         @inbounds h.vals[index] = v
     else
-        _setindex!(h, v, key, -index)
+        _setindex!(h, v, key, -index, h2)
     end
-
     return h
 end
 
@@ -349,12 +426,14 @@ function get!(h::OrderedDict{K,V}, key0, default) where {K,V}
         throw(ArgumentError("$key0 is not a valid key for type $K"))
     end
 
-    index = ht_keyindex2(h, key)
+    length(h.ctrl) == 0 && rehash!(h, 16)
 
+    h1, h2 = split_hash(key)
+    index = ht_keyindex2_h(h, key, h1, h2)
     index > 0 && return h.vals[index]
 
-    v = convert(V,  default)
-    _setindex!(h, v, key, -index)
+    v = convert(V, default)
+    _setindex!(h, v, key, -index, h2)
     return v
 end
 
@@ -364,20 +443,23 @@ function get!(default::Base.Callable, h::OrderedDict{K,V}, key0) where {K,V}
         throw(ArgumentError("$key0 is not a valid key for type $K"))
     end
 
-    index = ht_keyindex2(h, key)
+    length(h.ctrl) == 0 && rehash!(h, 16)
 
+    h1, h2 = split_hash(key)
+    index = ht_keyindex2_h(h, key, h1, h2)
     index > 0 && return h.vals[index]
 
     h.dirty = false
-    v = convert(V,  default())
-    if h.dirty  # calling default could have dirtied h
-        index = ht_keyindex2(h, key)
+    v = convert(V, default())
+    if h.dirty
+        length(h.ctrl) == 0 && rehash!(h, 16)
+        index = ht_keyindex2_h(h, key, h1, h2)
     end
     if index > 0
-        h.keys[index] = key
-        h.vals[index] = v
+        @inbounds h.keys[index] = key
+        @inbounds h.vals[index] = v
     else
-        _setindex!(h, v, key, -index)
+        _setindex!(h, v, key, -index, h2)
     end
     return v
 end
@@ -405,49 +487,56 @@ function getkey(h::OrderedDict{K,V}, key, default) where {K,V}
     return (index<0) ? default : h.keys[index]::K
 end
 
-function _pop!(h::OrderedDict, index)
-    @inbounds val = h.vals[h.slots[index]]
-    _delete!(h, index)
+function _pop!(h::OrderedDict, slot::Int)
+    @inbounds val = h.vals[h.idx[slot]]
+    _delete!(h, slot)
     return val
 end
 
 function pop!(h::OrderedDict)
     h.ndel > 0 && rehash!(h)
     key = h.keys[end]
-    index = ht_keyindex(h, key, false)
-    return key => _pop!(h, index)
+    slot = ht_keyindex(h, key, false)
+    return key => _pop!(h, slot)
 end
 
 function popfirst!(h::OrderedDict)
     h.ndel > 0 && rehash!(h)
     key = h.keys[1]
-    index = ht_keyindex(h, key, false)
-    key => _pop!(h, index)
+    slot = ht_keyindex(h, key, false)
+    return key => _pop!(h, slot)
 end
 
 function pop!(h::OrderedDict, key)
-    index = ht_keyindex(h, key, false)
-    index > 0 ? _pop!(h, index) : throw(KeyError(key))
+    slot = ht_keyindex(h, key, false)
+    return slot > 0 ? _pop!(h, slot) : throw(KeyError(key))
 end
 
 function pop!(h::OrderedDict, key, default)
-    index = ht_keyindex(h, key, false)
-    index > 0 ? _pop!(h, index) : default
+    slot = ht_keyindex(h, key, false)
+    return slot > 0 ? _pop!(h, slot) : default
 end
 
-function _delete!(h::OrderedDict, index)
-    @inbounds ki = h.slots[index]
-    @inbounds h.slots[index] = -ki
-    @inbounds Base._unsetindex!(h.keys, Int(ki))
-    @inbounds Base._unsetindex!(h.vals, Int(ki))
+function _delete!(h::OrderedDict, slot::Int)
+    @inbounds i = h.idx[slot]
+    Base._unsetindex!(h.keys, Int(i))
+    Base._unsetindex!(h.vals, Int(i))
     h.ndel += 1
     h.dirty = true
+
+    g_idx = ((slot - 1) >> 4) + 1
+    g = load_group(h.ctrl, g_idx)
+    if match_byte(g, CTRL_EMPTY) != 0
+        set_ctrl_byte!(h.ctrl, slot, CTRL_EMPTY)
+    else
+        set_ctrl_byte!(h.ctrl, slot, CTRL_DELETED)
+    end
     return h
 end
 
 function delete!(h::OrderedDict, key)
-    index = ht_keyindex(h, key, false)
-    if index > 0; _delete!(h, index); end
+    slot = ht_keyindex(h, key, false)
+    slot > 0 && _delete!(h, slot)
     return h
 end
 
@@ -499,15 +588,10 @@ merge(combine::Function, d::OrderedDict, others::AbstractDict...) = mergewith(co
 
 function Base.map!(f, iter::Base.ValueIterator{<:OrderedDict})
     dict = iter.dict
+    dict.ndel > 0 && rehash!(dict)
     vals = dict.vals
-    elements = length(vals) - dict.ndel
-    elements == 0 && return iter
-    for i in dict.slots
-        if i > 0
-            @inbounds vals[i] = f(vals[i])
-            elements -= 1
-            elements == 0 && break
-        end
+    @inbounds for i in 1:length(vals)
+        vals[i] = f(vals[i])
     end
     return iter
 end

--- a/src/ordered_set.jl
+++ b/src/ordered_set.jl
@@ -18,10 +18,11 @@ struct OrderedSet{T}  <: AbstractSet{T}
     OrderedSet{T}(xs) where {T} = union!(OrderedSet{T}(), xs)
     function OrderedSet{T}(s::Base.KeySet{T, <:OrderedDict{T}}) where {T}
         d = s.dict
-        slots = copy(d.slots)
+        ctrl = copy(d.ctrl)
+        idx = copy(d.idx)
         keys = copy(d.keys)
         vals = similar(d.vals, Nothing)
-        new{T}(OrderedDict{T,Nothing}(slots, keys, vals, d.ndel, d.maxprobe, d.dirty))
+        new{T}(OrderedDict{T,Nothing}(ctrl, idx, keys, vals, d.ndel, d.dirty))
     end
 end
 

--- a/test/test_ordered_dict.jl
+++ b/test/test_ordered_dict.jl
@@ -3,7 +3,7 @@ using OrderedCollections, Test
 @testset "OrderedDict" begin
 
     @testset "Constructors" begin
-        @test isa(@inferred(OrderedDict{Int,Float64}(zeros(Int,16), Vector{Int}(), Vector{Float64}(), 0, 0, false)), OrderedDict{Int,Float64})
+        @test isa(@inferred(OrderedDict{Int,Float64}(OrderedCollections.Memory{NTuple{16,UInt8}}(undef, 0), OrderedCollections.Memory{Int32}(undef, 0), Vector{Int}(), Vector{Float64}(), 0, false)), OrderedDict{Int,Float64})
         @test isa(@inferred(OrderedDict()), OrderedDict{Any,Any})
         @test isa(@inferred(OrderedDict([(1,2.0)])), OrderedDict{Int,Float64})
         @test isa(@inferred(OrderedDict([("a",1),("b",2)])), OrderedDict{String,Int})
@@ -493,17 +493,16 @@ using OrderedCollections, Test
         x[x] = 0  # There's no reason to ever do this, but it shouldn't overflow the stack
         @test length(deepcopy(x)) == 1
 
-        # Test that a rehash isn't triggered during setindex! with only a few keys added/removed.
-        # It should only be triggered when a count equal to 3/4 of the slots have been removed.
-        # With the smallest size dict, that would be 12/16
+        # Small numbers of deletes and inserts should not cause the table to grow.
+        # (Internals differ from the original probe-based design, but the user-visible
+        # invariant — rehashes don't fire on light churn — is the same.)
         od = OrderedDict{Int,Int}(i=>i for i in 1:5)
+        nslots_before = OrderedCollections._current_nslots(od)
         for i in 1:4
             pop!(od, i)
         end
-        del_slots1 = sum(od.slots .< 0)
         od[6] = 6
-        del_slots2 = sum(od.slots .< 0)
-        @test del_slots1 - 1 <= del_slots2 <= del_slots1
+        @test OrderedCollections._current_nslots(od) == nslots_before
 
         for i in 7:14
             od[i] = i
@@ -511,14 +510,13 @@ using OrderedCollections, Test
         for i in 5:13
             pop!(od, i)
         end
-        del_slots3 = sum(od.slots .< 0)
-        # Some of the previously deleted slots might have been reused, but we should at
-        # least see deleted slots for items 5 through 13
-        @test del_slots3 >= 9
-        # We've now removed 13 items, so the next assignment should trigger a rehash
+        # End state: only key 14 remains live; ndel reflects the deleted ones.
+        @test length(od) == 1
+        @test haskey(od, 14)
+        # Final insert should still leave the dict in a consistent state.
         od[15] = 15
-        del_slots4 = sum(od.slots .< 0)
-        @test del_slots4 == 0
+        @test length(od) == 2
+        @test od[14] == 14 && od[15] == 15
     end
 
     @testset "Issue #86" begin
@@ -553,3 +551,203 @@ using OrderedCollections, Test
     end
 
 end # @testset OrderedDict
+
+@testset "Swiss-table primitives: hash split + group selection" begin
+    import OrderedCollections: split_hash, group_for, slot_in_group, next_group_idx
+
+    for k in (1, "abc", :foo, 1.5, (1,2), nothing)
+        h1, h2 = split_hash(k)
+        @test h1 isa UInt
+        @test h2 isa UInt8
+        @test h2 <= 0x7F
+    end
+
+    for ngroups in (1, 2, 4, 16, 1024)
+        for trial in 1:50
+            h1 = rand(UInt)
+            g = group_for(h1, ngroups)
+            @test 1 <= g <= ngroups
+        end
+    end
+
+    @test slot_in_group(1, 0) == 1
+    @test slot_in_group(1, 15) == 16
+    @test slot_in_group(2, 0) == 17
+    @test slot_in_group(5, 3) == 68
+
+    for ngroups in (1, 2, 4, 8, 16, 32)
+        visited = Set{Int}()
+        g = 1
+        step = 1
+        for _ in 1:ngroups
+            push!(visited, g)
+            g = next_group_idx(g, step, ngroups)
+            step += 1
+        end
+        @test length(visited) == ngroups
+    end
+end
+
+@testset "Swiss-table primitives: group-scan ops" begin
+    import OrderedCollections: match_byte, match_empty_or_deleted, CTRL_EMPTY, CTRL_DELETED
+
+    g_empty = ntuple(_ -> CTRL_EMPTY, Val(16))
+    @test match_byte(g_empty, 0x42) == 0
+    @test match_byte(g_empty, CTRL_EMPTY) == 0xFFFF
+    @test match_empty_or_deleted(g_empty) == 0xFFFF
+
+    g_del = ntuple(_ -> CTRL_DELETED, Val(16))
+    @test match_byte(g_del, 0x42) == 0
+    @test match_byte(g_del, CTRL_EMPTY) == 0
+    @test match_empty_or_deleted(g_del) == 0xFFFF
+
+    g_full = ntuple(_ -> 0x42, Val(16))
+    @test match_byte(g_full, 0x42) == 0xFFFF
+    @test match_byte(g_full, 0x43) == 0
+    @test match_byte(g_full, CTRL_EMPTY) == 0
+    @test match_empty_or_deleted(g_full) == 0
+
+    bytes = fill(0x10, 16)
+    bytes[1] = 0x05
+    bytes[8] = CTRL_EMPTY
+    bytes[13] = CTRL_DELETED
+    g_mix = ntuple(i -> bytes[i], Val(16))
+    @test match_byte(g_mix, 0x05) == 0x0001
+    @test match_byte(g_mix, 0x10) == 0xEF7E
+    @test match_byte(g_mix, CTRL_EMPTY) == 0x0080
+    @test match_empty_or_deleted(g_mix) == 0x1080
+end
+
+@testset "Swiss-table primitives: ctrl I/O" begin
+    import OrderedCollections: load_group, set_ctrl_byte!, _empty_group, Memory
+
+    @test all(b -> b == 0x80, _empty_group)
+
+    ngroups = 2
+    ctrl = Memory{NTuple{16,UInt8}}(undef, ngroups)
+    fill!(ctrl, _empty_group)
+    g1 = load_group(ctrl, 1)
+    @test all(b -> b == 0x80, g1)
+
+    set_ctrl_byte!(ctrl, 5, 0x42)
+    g1 = load_group(ctrl, 1)
+    @test g1[5] == 0x42
+    @test g1[4] == 0x80 && g1[6] == 0x80
+
+    set_ctrl_byte!(ctrl, 17, 0x33)
+    g2 = load_group(ctrl, 2)
+    @test g2[1] == 0x33
+
+    set_ctrl_byte!(ctrl, 1, 0x77)
+    @test load_group(ctrl, 1)[1] == 0x77
+end
+
+# --- Swiss-table test helper types (module scope) ---
+
+struct OneGroupKey
+    v::Int
+end
+Base.hash(k::OneGroupKey, h::UInt) = h
+Base.isequal(a::OneGroupKey, b::OneGroupKey) = a.v == b.v
+Base.:(==)(a::OneGroupKey, b::OneGroupKey) = a.v == b.v
+
+struct H2Twin
+    v::Int
+    h::UInt
+end
+Base.hash(k::H2Twin, h::UInt) = k.h
+Base.isequal(a::H2Twin, b::H2Twin) = a.v == b.v
+Base.:(==)(a::H2Twin, b::H2Twin) = a.v == b.v
+
+@testset "Swiss: group-boundary stress" begin
+    d = OrderedDict{OneGroupKey,Int}()
+    for i in 1:32
+        d[OneGroupKey(i)] = i * 100
+    end
+    @test length(d) == 32
+    for i in 1:32
+        @test d[OneGroupKey(i)] == i * 100
+    end
+    @test [k.v for (k, _) in d] == collect(1:32)
+
+    for i in 2:2:32
+        delete!(d, OneGroupKey(i))
+    end
+    @test length(d) == 16
+    @test [k.v for (k, _) in d] == collect(1:2:31)
+    for i in 1:2:31
+        @test d[OneGroupKey(i)] == i * 100
+    end
+end
+
+@testset "Swiss: h2 fingerprint collisions" begin
+    top = UInt(0x42) << (8*sizeof(UInt) - 7)
+    a = H2Twin(1, top | UInt(1))
+    b = H2Twin(2, top | UInt(2))
+
+    d = OrderedDict{H2Twin,String}()
+    d[a] = "alpha"
+    d[b] = "beta"
+
+    @test d[a] == "alpha"
+    @test d[b] == "beta"
+    @test length(d) == 2
+    @test !haskey(d, H2Twin(3, top | UInt(3)))
+end
+
+@testset "Swiss: tombstone vs empty after delete" begin
+    d = OrderedDict{Int,Int}()
+    for i in 1:50
+        d[i] = i * 10
+    end
+    for i in 1:5:50
+        delete!(d, i)
+    end
+    @test length(d) == 50 - 10
+    for i in 1:50
+        if i % 5 == 1
+            @test !haskey(d, i)
+        else
+            @test d[i] == i * 10
+        end
+    end
+    for i in 100:130
+        d[i] = i
+    end
+    for i in 100:130
+        @test d[i] == i
+    end
+end
+
+@testset "Swiss: operations on empty dict" begin
+    d = OrderedDict{Int,Int}()
+    @test length(d.ctrl) == 0
+    @test length(d.idx) == 0
+    @test length(d) == 0
+    @test isempty(d)
+    @test !haskey(d, 1)
+    @test get(d, 1, -1) == -1
+    @test_throws KeyError d[1]
+    @test_throws KeyError pop!(d, 1)
+    @test pop!(d, 1, :nope) === :nope
+    delete!(d, 1)
+    @test length(d) == 0
+    @test collect(d) == Pair{Int,Int}[]
+
+    d[1] = 10
+    @test length(d.ctrl) > 0
+    @test d[1] == 10
+end
+
+@testset "Swiss: large table grows correctly" begin
+    d = OrderedDict{Int,Int}()
+    N = 200_000
+    for i in 1:N
+        d[i] = i
+    end
+    @test length(d) == N
+    for i in 1:N
+        @test d[i] == i
+    end
+    @test [k for (k, _) in d] == collect(1:N)
+end

--- a/test/test_ordered_set.jl
+++ b/test/test_ordered_set.jl
@@ -3,7 +3,7 @@ using OrderedCollections, Test
 @testset "OrderedSet" begin
 
     @testset "Constructors" begin
-        @test isa(OrderedSet{Int}(keys(OrderedDict{Int,Float64}(zeros(Int,16), Vector{Int}(), Vector{Float64}(), 0, 0, false))), OrderedSet{Int})
+        @test isa(OrderedSet{Int}(keys(OrderedDict{Int,Float64}(OrderedCollections.Memory{NTuple{16,UInt8}}(undef, 0), OrderedCollections.Memory{Int32}(undef, 0), Vector{Int}(), Vector{Float64}(), 0, false))), OrderedSet{Int})
         @test isa(OrderedSet{Int}(keys(OrderedDict([(1,2.0)]))), OrderedSet{Int})
         @test isa(OrderedSet(), OrderedSet{Any})
         @test isa(OrderedSet([1,2,3]), OrderedSet{Int})


### PR DESCRIPTION
Rewrite OrderedDict internals using Swiss-table layout
Replaces the open-addressed `slots::Vector{Int32}` table with parallel
`ctrl::Memory{NTuple{16,UInt8}}` (one byte per slot, holding empty/deleted
sentinels or a 7-bit h2 fingerprint) 
and `idx::Memory{Int32}` (raw indices into keys/vals, only read when ctrl says the slot is full).
Lookups scan 16 control bytes per probe step using a portable LLVM bitcast
intrinsic that lowers to pmovmskb on x86 and the NEON equivalent on aarch64 (It really bothers me that this was needed and autovec didn't give equal results).

Design choices worth highlighting:

* Empty OrderedDict allocates nothing: ctrl/idx start as zero-length
  Memory; the first insert allocates a 16-slot table.
* Load factor moves from 2/3 to 7/8 (denser tables, less memory for
  the same entry count).
* Group-aligned addressing — ctrl is stored as a sequence of 16-byte
  tuples and indexed by group, not slot.
* Single-group fast path on length(ctrl) == 1, factored over a shared
  _find_h2_in_group helper to avoid duplicating the probe body between
  the fast and general paths.
* Tombstone-vs-empty optimization on delete: if the affected group still
  has at least one empty byte, mark the deleted slot 0x80 instead of
  0xFE so probe chains stay short without rehashing.
* Rehash compaction walks ctrl to build a BitVector of live
  keys-positions and iterates keys in insertion order — uniform for
  isbits and pointer K (no isassigned/probe-walk branch).
* split_hash is computed once in setindex!/get! and threaded into
  ht_keyindex2_h via a separate entry, so self-referential dicts
  (x[x] = 0) don't infinite-loop on a second hash(x) call after push.

OrderedSet's KeySet constructor adapts to the new struct shape; a couple
of pre-existing tests that constructed OrderedDict via the all-fields
constructor are updated accordingly. Issue https://github.com/JuliaCollections/OrderedCollections.jl/issues/65's rehash-threshold test
is rewritten against the new invariants (it used to inspect od.slots).

Removed from dict_support.jl: hashindex and _tablesz, both unused after
the rewrite. The legacy maxprobe/maxallowedprobe/maxprobeshift constants
and the isslotempty/isslotfilled/isslotmissing helpers are gone too —
probe termination is governed by the first empty ctrl byte we see, not
by a probe counter.

Bench numbers (Julia 1.12, x86-64 with AVX-512, ~10-15% run-to-run noise):

  Workload                   |  Old  | New  | Ratio
  ---------------------------+-------+------+------
  lookup_miss  @ 1M entries  | 30.5ms | 14.5ms | 0.48x — 2.1x faster
  lookup_miss  @ 65K entries | 841μs | 369μs  | 0.44x — 2.3x faster
  lookup_miss  @ 4K entries  | 28.8μs| 21.2μs | 0.74x — 1.4x faster
  insert       @ 1M entries  | 48.3ms| 39.6ms | 0.82x — 1.2x faster
  lookup_hit   @ 65K, 1M     | flat   | flat   | ≈1.00x
  iterate                    | flat   | flat   | ≈1.00x
  update existing key, N≤12  | flat   | flat   | at parity with Base.Dict
  lookup_hit   @ 16-4K       | 3.5ns  | 5.5-6ns| 1.5-1.7x slower

The small-size lookup_hit regression is structural — the per-call setup
for the Swiss-table probe (split_hash, group_for, slot_in_group) costs a
few extra ns vs the old code's single hash & mask + slots[index] fast
path. For ergonomic inner-loop perf on tiny dicts, LittleDict remains
the recommended alternative.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>