### PR TITLE
OrderedDict: improve performance for non-concrete values and keys

### DIFF
--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -451,28 +451,28 @@ function delete!(h::OrderedDict, key)
     return h
 end
 
-function iterate(t::OrderedDict)
+function iterate(t::OrderedDict{K,V}) where {K,V}
     t.ndel > 0 && rehash!(t)
     length(t.keys) < 1 && return nothing
-    return (Pair(t.keys[1], t.vals[1]), 2)
+    @inbounds return (Pair{K,V}(t.keys[1], t.vals[1]), 2)
 end
-function iterate(t::OrderedDict, i)
+function iterate(t::OrderedDict{K,V}, i) where {K,V}
     length(t.keys) < i && return nothing
-    return (Pair(t.keys[i], t.vals[i]), i+1)
+    @inbounds return (Pair{K,V}(t.keys[i], t.vals[i]), i+1)
 end
 
 # lazy reverse iteration
-function iterate(rt::Iterators.Reverse{<:OrderedDict})
+function iterate(rt::Iterators.Reverse{<:OrderedDict{K,V}}) where {K,V}
     t = rt.itr
     t.ndel > 0 && rehash!(t)
     n = length(t.keys)
     n < 1 && return nothing
-    return (Pair(t.keys[n], t.vals[n]), n - 1)
+    @inbounds return (Pair{K,V}(t.keys[n], t.vals[n]), n - 1)
 end
-function iterate(rt::Iterators.Reverse{<:OrderedDict}, i)
+function iterate(rt::Iterators.Reverse{<:OrderedDict{K,V}}, i) where {K,V}
     t = rt.itr
     i < 1 && return nothing
-    return (Pair(t.keys[i], t.vals[i]), i - 1)
+    @inbounds return (Pair{K,V}(t.keys[i], t.vals[i]), i - 1)
 end
 
 


### PR DESCRIPTION
Using the following benchmark

```julia
  using OrderedCollections
  using BenchmarkTools

  const N = 1000
  pairs = [i => (iseven(i) ? i : Float64(i)) for i in 1:N]

  d_base = Dict{Int,Number}(pairs)
  d_ord  = OrderedDict{Int,Number}(pairs)

  function sumvals(d)
      s = 0.0
      for (k, v) in d
          s += v
      end
      return s
  end

  println(Base.return_types(iterate, (Dict{Int,Number},))[1])
  println(Base.return_types(iterate, (OrderedDict{Int,Number},))[1])

  @btime sumvals($d_base)
  @btime sumvals($d_ord)
```

 I get:

```
  # Base:
  #  16.441 μs (1000 allocations: 15.62 KiB)
  # Ordered Before PR
  # 179.508 μs (6214 allocations: 143.97 KiB)
  # Ordered After PR:
  # 9.180 μs (1000 allocations: 15.62 KiB)
```

This mirrors how Base does it https://github.com/JuliaLang/julia/blob/3e1bf51ccd6f5cb8a547ca99d0fd33de24ac85e8/base/dict.jl#L701