### PR TITLE
Optimize `OrderedDict` performance 

### DIFF
--- a/src/dict_sorting.jl
+++ b/src/dict_sorting.jl
@@ -6,27 +6,36 @@ function sort!(d::OrderedDict; byvalue::Bool=false, args...)
         rehash!(d)
     end
 
-    data = byvalue ? d.vals : d.keys
+    n = d.len
+    keys = d.keys
+    vals = d.vals
+    # Only the live prefix 1:n is meaningful; the Memory tail is undef.
+    data = view(byvalue ? vals : keys, 1:n)
 
     # Filter out the kwargs supported by issorted (notably, :alg needs to be removed)
     issorted_kw = NamedTuple(k => v for (k, v) in args if k in (:lt, :by, :rev, :order))
     issorted(data; issorted_kw...) && return d
 
     p = sortperm(data; args...)
-    d.keys = d.keys[p]
-    d.vals = d.vals[p]
+    newkeys = similar(keys, n)
+    newvals = similar(vals, n)
+    @inbounds for i in 1:n
+        newkeys[i] = keys[p[i]]
+        newvals[i] = vals[p[i]]
+    end
+    @inbounds copyto!(keys, 1, newkeys, 1, n)
+    @inbounds copyto!(vals, 1, newvals, 1, n)
     rehash!(d)
     return d
 end
 
 # Compared to just sorting the underlying OrderedDict, this method calls sort!
-# directly on the keys (no need to sort d.vals::Vector{Nothing}). This saves
-# the allocation of the permutation vector in sortperm, and subsequent
-# allocations of new d.keys and d.vals vectors.
+# directly on the keys (no need to sort d.vals::Memory{Nothing}). This saves
+# the allocation of the permutation vector in sortperm.
 function sort!(s::OrderedSet; kwargs...)
     d = s.dict
     d.ndel > 0 && rehash!(d)
-    sort!(d.keys; kwargs...)
+    sort!(view(d.keys, 1:d.len); kwargs...)
     rehash!(d)
     return s
 end

--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -327,7 +327,7 @@ function get!(h::OrderedDict{K,V}, key0, default) where {K,V}
 
     index = ht_keyindex2(h, key)
 
-    index > 0 && return h.vals[index]
+    index > 0 && return @inbounds h.vals[index]
 
     v = convert(V,  default)
     _setindex!(h, v, key, -index)
@@ -342,7 +342,7 @@ function get!(default::Base.Callable, h::OrderedDict{K,V}, key0) where {K,V}
 
     index = ht_keyindex2(h, key)
 
-    index > 0 && return h.vals[index]
+    index > 0 && return @inbounds h.vals[index]
 
     h.dirty = false
     v = convert(V,  default())
@@ -350,8 +350,8 @@ function get!(default::Base.Callable, h::OrderedDict{K,V}, key0) where {K,V}
         index = ht_keyindex2(h, key)
     end
     if index > 0
-        h.keys[index] = key
-        h.vals[index] = v
+        @inbounds h.keys[index] = key
+        @inbounds h.vals[index] = v
     else
         _setindex!(h, v, key, -index)
     end
@@ -360,17 +360,18 @@ end
 
 function getindex(h::OrderedDict{K,V}, key) where {K,V}
     index = ht_keyindex(h, key)
-    return (index<0) ? throw(KeyError(key)) : h.vals[index]::V
+    # index, when >= 0, is a valid position returned by ht_keyindex
+    return (index<0) ? throw(KeyError(key)) : (@inbounds h.vals[index]::V)
 end
 
 function get(h::OrderedDict{K,V}, key, default) where {K,V}
     index = ht_keyindex(h, key)
-    return (index<0) ? default : h.vals[index]::V
+    return (index<0) ? default : (@inbounds h.vals[index]::V)
 end
 
 function get(default::Base.Callable, h::OrderedDict{K,V}, key) where {K,V}
     index = ht_keyindex(h, key)
-    return (index<0) ? default() : h.vals[index]::V
+    return (index<0) ? default() : (@inbounds h.vals[index]::V)
 end
 
 haskey(h::OrderedDict, key) = (ht_keyindex(h, key) >= 0)
@@ -378,7 +379,7 @@ in(key, v::Base.KeySet{K,T}) where {K,T<:OrderedDict{K}} = (ht_keyindex(v.dict, 
 
 function getkey(h::OrderedDict{K,V}, key, default) where {K,V}
     index = ht_keyindex(h, key)
-    return (index<0) ? default : h.keys[index]::K
+    return (index<0) ? default : (@inbounds h.keys[index]::K)
 end
 
 function _pop!(h::OrderedDict, index)

--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -12,14 +12,15 @@ refers to insertion order, which allows deterministic iteration over the diction
 """
 mutable struct OrderedDict{K,V} <: AbstractDict{K,V}
     slots::Memory{Int32}
-    keys::Vector{K}
-    vals::Vector{V}
+    keys::Memory{K}
+    vals::Memory{V}
+    len::Int
     ndel::Int
     dirty::Bool
 end
 
 function OrderedDict{K,V}() where {K,V}
-    OrderedDict{K,V}(Memory{Int32}(undef, 0), Vector{K}(), Vector{V}(), 0, false)
+    OrderedDict{K,V}(Memory{Int32}(undef, 0), Memory{K}(undef, 0), Memory{V}(undef, 0), 0, 0, false)
 end
 
 function OrderedDict{K,V}(kv) where {K,V}
@@ -46,7 +47,7 @@ function OrderedDict{K,V}(d::OrderedDict{K,V}) where {K,V}
         rehash!(d)
     end
     @assert d.ndel == 0
-    OrderedDict{K,V}(copy(d.slots), copy(d.keys), copy(d.vals), 0, false)
+    OrderedDict{K,V}(copy(d.slots), copy(d.keys), copy(d.vals), d.len, 0, false)
 end
 
 OrderedDict() = OrderedDict{Any,Any}()
@@ -87,7 +88,7 @@ end
 empty(d::OrderedDict{K,V}) where {K,V} = OrderedDict{K,V}()
 empty(d::OrderedDict, ::Type{K}, ::Type{V}) where {K, V} = OrderedDict{K, V}()
 
-length(d::OrderedDict) = length(d.keys) - d.ndel
+length(d::OrderedDict) = d.len - d.ndel
 isempty(d::OrderedDict) = (length(d) == 0)
 
 """
@@ -123,53 +124,54 @@ isslotmissing(slot_value::Integer) = slot_value < 0
 
 function rehash!(h::OrderedDict{K,V}, newsz::Integer = length(h.slots)) where {K,V}
     olds = h.slots
-    keys = h.keys
-    vals = h.vals
+    oldk = h.keys
+    oldv = h.vals
     sz = length(olds)
+    oldlen = h.len
     newsz = _tablesz(newsz)
     h.dirty = true
     count0 = length(h)
     if count0 == 0
-        h.slots = Memory{Int32}(undef, newsz)
-        fill!(h.slots, 0)
-        resize!(h.keys, 0)
-        resize!(h.vals, 0)
+        h.slots = Memory{Int32}(undef, newsz); fill!(h.slots, 0)
+        h.keys = Memory{K}(undef, newsz)
+        h.vals = Memory{V}(undef, newsz)
+        h.len = 0
         h.ndel = 0
         return h
     end
 
-    slots = Memory{Int32}(undef, newsz)
-    fill!(slots, 0)
+    slots = Memory{Int32}(undef, newsz); fill!(slots, 0)
+    newkeys = Memory{K}(undef, newsz)
+    newvals = Memory{V}(undef, newsz)
 
     if h.ndel > 0
         # Mark live positions by walking the old slot table, then compact in
         # ascending position order so insertion order is preserved.
-        live = falses(length(keys))
+        live = falses(oldlen)
         @inbounds for index in 1:sz
             si = olds[index]
             si > 0 && (live[si] = true)
         end
-        newkeys = similar(keys, count0)
-        newvals = similar(vals, count0)
         to = 1
-        @inbounds for from in 1:length(keys)
+        @inbounds for from in 1:oldlen
             live[from] || continue
-            k = keys[from]
+            k = oldk[from]
             index = hashindex(k, newsz)
             while slots[index] != 0
                 index = (index & (newsz-1)) + 1
             end
             slots[index] = to
             newkeys[to] = k
-            newvals[to] = vals[from]
+            newvals[to] = oldv[from]
             to += 1
         end
-        h.keys = newkeys
-        h.vals = newvals
+        h.len = to - 1
         h.ndel = 0
     else
-        @inbounds for i = 1:count0
-            k = keys[i]
+        @inbounds copyto!(newkeys, 1, oldk, 1, oldlen)
+        @inbounds copyto!(newvals, 1, oldv, 1, oldlen)
+        @inbounds for i = 1:oldlen
+            k = newkeys[i]
             index = hashindex(k, newsz)
             while slots[index] != 0
                 index = (index & (newsz-1)) + 1
@@ -179,6 +181,8 @@ function rehash!(h::OrderedDict{K,V}, newsz::Integer = length(h.slots)) where {K
     end
 
     h.slots = slots
+    h.keys = newkeys
+    h.vals = newvals
     return h
 end
 
@@ -198,8 +202,7 @@ end
 
 function empty!(h::OrderedDict{K,V}) where {K,V}
     fill!(h.slots, 0)
-    empty!(h.keys)
-    empty!(h.vals)
+    h.len = 0
     h.ndel = 0
     h.dirty = true
     return h
@@ -267,19 +270,26 @@ function ht_keyindex2(h::OrderedDict{K,V}, key) where {K,V}
     end
 end
 
+# Append a new entry at position len+1. Capacity is guaranteed by the rehash
+# trigger in _setindex! (cap(keys) == length(slots) == sz, and len < sz holds
+# entering each append), so no bounds-grow check is needed.
+@inline function _append!(h::OrderedDict, key, v)
+    nk = h.len + 1
+    h.len = nk
+    @inbounds h.keys[nk] = key
+    @inbounds h.vals[nk] = v
+    return nk
+end
+
 function _setindex!(h::OrderedDict, v, key, index)
-    hk, hv = h.keys, h.vals
-    push!(hk, key)
-    push!(hv, v)
-    nk = length(hk)
+    nk = _append!(h, key, v)
     @inbounds h.slots[index] = nk
     h.dirty = true
 
     sz = length(h.slots)
     cnt = nk - h.ndel
-    # Rehash now if necessary
-    if h.ndel >= ((3*nk)>>2) > 4 || cnt*3 > sz*2
-        # > 3/4 deleted or > 2/3 full
+    # Rehash now if necessary: > 3/4 dead, > 2/3 live, or keys/vals capacity hit.
+    if h.ndel >= ((3*nk)>>2) > 4 || cnt*3 > sz*2 || nk >= sz
         rehash!(h, cnt > 64000 ? cnt*2 : cnt*4)
     end
 end
@@ -373,7 +383,7 @@ end
 
 function pop!(h::OrderedDict)
     h.ndel > 0 && rehash!(h)
-    key = h.keys[end]
+    key = h.keys[h.len]
     index = ht_slotindex(h, key)
     return key => _pop!(h, index)
 end
@@ -413,11 +423,11 @@ end
 
 function iterate(t::OrderedDict{K,V}) where {K,V}
     t.ndel > 0 && rehash!(t)
-    length(t.keys) < 1 && return nothing
+    t.len < 1 && return nothing
     @inbounds return (Pair{K,V}(t.keys[1], t.vals[1]), 2)
 end
 function iterate(t::OrderedDict{K,V}, i) where {K,V}
-    length(t.keys) < i && return nothing
+    t.len < i && return nothing
     @inbounds return (Pair{K,V}(t.keys[i], t.vals[i]), i+1)
 end
 
@@ -425,7 +435,7 @@ end
 function iterate(rt::Iterators.Reverse{<:OrderedDict{K,V}}) where {K,V}
     t = rt.itr
     t.ndel > 0 && rehash!(t)
-    n = length(t.keys)
+    n = t.len
     n < 1 && return nothing
     @inbounds return (Pair{K,V}(t.keys[n], t.vals[n]), n - 1)
 end
@@ -460,7 +470,7 @@ merge(combine::Function, d::OrderedDict, others::AbstractDict...) = mergewith(co
 function Base.map!(f, iter::Base.ValueIterator{<:OrderedDict})
     dict = iter.dict
     vals = dict.vals
-    elements = length(vals) - dict.ndel
+    elements = length(dict)
     elements == 0 && return iter
     for i in dict.slots
         if i > 0
@@ -472,4 +482,4 @@ function Base.map!(f, iter::Base.ValueIterator{<:OrderedDict})
     return iter
 end
 
-last(h::OrderedDict) = h.keys[end] => h.vals[end]
+last(h::OrderedDict) = h.keys[h.len] => h.vals[h.len]

--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -19,8 +19,14 @@ mutable struct OrderedDict{K,V} <: AbstractDict{K,V}
     dirty::Bool
 end
 
+# Shared read-only slot table for empty dicts: a single empty slot, so that
+# ht_keyindex runs its normal probe (index 1 reads 0 -> not found) with no
+# per-call emptiness branch on the hot path. Never mutated: ht_keyindex2 grows
+# to a real table before any write, so all empty dicts can alias this safely.
+const _EMPTY_SLOTS = (let m = Memory{Int32}(undef, 1); @inbounds m[1] = Int32(0); m end)
+
 function OrderedDict{K,V}() where {K,V}
-    OrderedDict{K,V}(Memory{Int32}(undef, 0), Memory{K}(undef, 0), Memory{V}(undef, 0), 0, 0, false)
+    OrderedDict{K,V}(_EMPTY_SLOTS, Memory{K}(undef, 0), Memory{V}(undef, 0), 0, 0, false)
 end
 
 function OrderedDict{K,V}(kv) where {K,V}
@@ -212,7 +218,6 @@ end
 function ht_keyindex(h::OrderedDict{K,V}, key) where {K,V}
     slots = h.slots
     sz = length(slots)
-    sz == 0 && return -1
     keys = h.keys
     index = hashindex(key, sz)
     @inbounds while true
@@ -229,7 +234,6 @@ end
 function ht_slotindex(h::OrderedDict{K,V}, key) where {K,V}
     slots = h.slots
     sz = length(slots)
-    sz == 0 && return -1
     keys = h.keys
     index = hashindex(key, sz)
     @inbounds while true
@@ -248,11 +252,6 @@ end
 function ht_keyindex2(h::OrderedDict{K,V}, key) where {K,V}
     slots = h.slots
     sz = length(slots)
-    if sz == 0
-        rehash!(h, 16)
-        slots = h.slots
-        sz = length(slots)
-    end
     keys = h.keys
     index = hashindex(key, sz)
     avail = 0
@@ -282,6 +281,13 @@ end
 end
 
 function _setindex!(h::OrderedDict, v, key, index)
+    if length(h.slots) <= 1
+        # Empty dict still aliasing the shared sentinel: grow to a real table,
+        # then recompute the insertion slot in it. Keeps ht_keyindex2 (the
+        # update/lookup path) free of any emptiness branch.
+        rehash!(h, 16)
+        index = -ht_keyindex2(h, key)
+    end
     nk = _append!(h, key, v)
     @inbounds h.slots[index] = nk
     h.dirty = true

--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -287,9 +287,14 @@ function _setindex!(h::OrderedDict, v, key, index)
     h.dirty = true
 
     sz = length(h.slots)
-    cnt = nk - h.ndel
-    # Rehash now if necessary: > 3/4 dead, > 2/3 live, or keys/vals capacity hit.
-    if h.ndel >= ((3*nk)>>2) > 4 || cnt*3 > sz*2 || nk >= sz
+    # nk == h.len: live + dead (tombstone/orphan) positions, and == keys/vals fill.
+    # Two reasons to rehash:
+    #  - load/capacity: slot occupancy <= nk, so >2/3 full bounds probe length and
+    #    keeps room to append (this also guarantees nk < sz);
+    #  - reclamation: >3/4 of positions are dead (tombstones/orphans).
+    # rehash! sizes to the live count, so a churn-heavy table compacts (may shrink).
+    if 3*nk > 2*sz || 4*h.ndel >= 3*nk
+        cnt = nk - h.ndel
         rehash!(h, cnt > 64000 ? cnt*2 : cnt*4)
     end
 end

--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -19,14 +19,8 @@ mutable struct OrderedDict{K,V} <: AbstractDict{K,V}
     dirty::Bool
 end
 
-# Shared read-only slot table for empty dicts: a single empty slot, so that
-# ht_keyindex runs its normal probe (index 1 reads 0 -> not found) with no
-# per-call emptiness branch on the hot path. Never mutated: ht_keyindex2 grows
-# to a real table before any write, so all empty dicts can alias this safely.
-const _EMPTY_SLOTS = (let m = Memory{Int32}(undef, 1); @inbounds m[1] = Int32(0); m end)
-
 function OrderedDict{K,V}() where {K,V}
-    OrderedDict{K,V}(_EMPTY_SLOTS, Memory{K}(undef, 0), Memory{V}(undef, 0), 0, 0, false)
+    OrderedDict{K,V}(Memory{Int32}(undef, 0), Memory{K}(undef, 0), Memory{V}(undef, 0), 0, 0, false)
 end
 
 function OrderedDict{K,V}(kv) where {K,V}
@@ -218,6 +212,7 @@ end
 function ht_keyindex(h::OrderedDict{K,V}, key) where {K,V}
     slots = h.slots
     sz = length(slots)
+    sz == 0 && return -1
     keys = h.keys
     index = hashindex(key, sz)
     @inbounds while true
@@ -234,6 +229,7 @@ end
 function ht_slotindex(h::OrderedDict{K,V}, key) where {K,V}
     slots = h.slots
     sz = length(slots)
+    sz == 0 && return -1
     keys = h.keys
     index = hashindex(key, sz)
     @inbounds while true
@@ -252,6 +248,11 @@ end
 function ht_keyindex2(h::OrderedDict{K,V}, key) where {K,V}
     slots = h.slots
     sz = length(slots)
+    if sz == 0
+        rehash!(h, 16)
+        slots = h.slots
+        sz = length(slots)
+    end
     keys = h.keys
     index = hashindex(key, sz)
     avail = 0
@@ -281,13 +282,6 @@ end
 end
 
 function _setindex!(h::OrderedDict, v, key, index)
-    if length(h.slots) <= 1
-        # Empty dict still aliasing the shared sentinel: grow to a real table,
-        # then recompute the insertion slot in it. Keeps ht_keyindex2 (the
-        # update/lookup path) free of any emptiness branch.
-        rehash!(h, 16)
-        index = -ht_keyindex2(h, key)
-    end
     nk = _append!(h, key, v)
     @inbounds h.slots[index] = nk
     h.dirty = true

--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -1,8 +1,8 @@
 using Base: isbitsunion
 
-# These can be changed, to trade off better performance for space
-const global maxallowedprobe = isdefined(Base, :maxallowedprobe) ? Base.maxallowedprobe : 16
-const global maxprobeshift   = isdefined(Base, :maxprobeshift) ? Base.maxprobeshift : 6
+if !isdefined(Base, :Memory)
+    const Memory = Vector
+end
 
 """
     OrderedDict
@@ -11,16 +11,15 @@ const global maxprobeshift   = isdefined(Base, :maxprobeshift) ? Base.maxprobesh
 refers to insertion order, which allows deterministic iteration over the dictionary.
 """
 mutable struct OrderedDict{K,V} <: AbstractDict{K,V}
-    slots::Vector{Int32}
+    slots::Memory{Int32}
     keys::Vector{K}
     vals::Vector{V}
     ndel::Int
-    maxprobe::Int
     dirty::Bool
 end
 
 function OrderedDict{K,V}() where {K,V}
-    OrderedDict{K,V}(zeros(Int32,16), Vector{K}(), Vector{V}(), 0, 0, false)
+    OrderedDict{K,V}(Memory{Int32}(undef, 0), Vector{K}(), Vector{V}(), 0, false)
 end
 
 function OrderedDict{K,V}(kv) where {K,V}
@@ -47,7 +46,7 @@ function OrderedDict{K,V}(d::OrderedDict{K,V}) where {K,V}
         rehash!(d)
     end
     @assert d.ndel == 0
-    OrderedDict{K,V}(copy(d.slots), copy(d.keys), copy(d.vals), 0, d.maxprobe, false)
+    OrderedDict{K,V}(copy(d.slots), copy(d.keys), copy(d.vals), 0, false)
 end
 
 OrderedDict() = OrderedDict{Any,Any}()
@@ -131,7 +130,7 @@ function rehash!(h::OrderedDict{K,V}, newsz::Integer = length(h.slots)) where {K
     h.dirty = true
     count0 = length(h)
     if count0 == 0
-        resize!(h.slots, newsz)
+        h.slots = Memory{Int32}(undef, newsz)
         fill!(h.slots, 0)
         resize!(h.keys, 0)
         resize!(h.vals, 0)
@@ -139,53 +138,31 @@ function rehash!(h::OrderedDict{K,V}, newsz::Integer = length(h.slots)) where {K
         return h
     end
 
-    slots = zeros(Int32, newsz)
-    maxprobe = 0
+    slots = Memory{Int32}(undef, newsz)
+    fill!(slots, 0)
 
     if h.ndel > 0
-        ndel0 = h.ndel
-        ptrs = !isbitstype(K) && !isbitsunion(K)
-        to = 1
-        # TODO: to get the best performance we need to avoid reallocating these.
-        # This algorithm actually works in place, unless the dict is modified
-        # due to GC during this process.
+        # Mark live positions by walking the old slot table, then compact in
+        # ascending position order so insertion order is preserved.
+        live = falses(length(keys))
+        @inbounds for index in 1:sz
+            si = olds[index]
+            si > 0 && (live[si] = true)
+        end
         newkeys = similar(keys, count0)
         newvals = similar(vals, count0)
-        @inbounds for from = 1:length(keys)
-            if !ptrs || isassigned(keys, from)
-                k = keys[from]
-                hashk = hash(k)%Int
-                isdeleted = false
-                if !ptrs
-                    iter = 0
-                    index = (hashk & (sz-1)) + 1
-                    while iter <= h.maxprobe
-                        si = olds[index]
-                        si == from && break
-                        # if we find si == 0, then the key was deleted and it's slot was reused/overwritten
-                        (si == -from || si == 0) && (isdeleted = true; break)
-                        index = (index & (sz-1)) + 1
-                        iter += 1
-                    end
-                    iter > h.maxprobe && (isdeleted = true)  # Another case where the slot was reused/overwritten
-                end
-                if !isdeleted
-                    index0 = index = (hashk & (newsz-1)) + 1
-                    while slots[index] != 0
-                        index = (index & (newsz-1)) + 1
-                    end
-                    probe = (index - index0) & (newsz-1)
-                    probe > maxprobe && (maxprobe = probe)
-                    slots[index] = to
-                    newkeys[to] = k
-                    newvals[to] = vals[from]
-                    to += 1
-                end
-                if h.ndel != ndel0
-                    # if items are removed by finalizers, retry
-                    return rehash!(h, newsz)
-                end
+        to = 1
+        @inbounds for from in 1:length(keys)
+            live[from] || continue
+            k = keys[from]
+            index = hashindex(k, newsz)
+            while slots[index] != 0
+                index = (index & (newsz-1)) + 1
             end
+            slots[index] = to
+            newkeys[to] = k
+            newvals[to] = vals[from]
+            to += 1
         end
         h.keys = newkeys
         h.vals = newvals
@@ -193,22 +170,15 @@ function rehash!(h::OrderedDict{K,V}, newsz::Integer = length(h.slots)) where {K
     else
         @inbounds for i = 1:count0
             k = keys[i]
-            index0 = index = hashindex(k, newsz)
+            index = hashindex(k, newsz)
             while slots[index] != 0
                 index = (index & (newsz-1)) + 1
             end
-            probe = (index - index0) & (newsz-1)
-            probe > maxprobe && (maxprobe = probe)
             slots[index] = i
-            if h.ndel > 0
-                # if items are removed by finalizers, retry
-                return rehash!(h, newsz)
-            end
         end
     end
 
     h.slots = slots
-    h.maxprobe = maxprobe
     return h
 end
 
@@ -235,28 +205,38 @@ function empty!(h::OrderedDict{K,V}) where {K,V}
     return h
 end
 
-# get the index where a key is stored, or -1 if not present
-function ht_keyindex(h::OrderedDict{K,V}, key, direct) where {K,V}
+# position of `key` in keys/vals (>0), or -1 if absent. Hot path for getindex.
+function ht_keyindex(h::OrderedDict{K,V}, key) where {K,V}
     slots = h.slots
     sz = length(slots)
-    iter = 0
-    maxprobe = h.maxprobe
-    index = hashindex(key, sz)
+    sz == 0 && return -1
     keys = h.keys
-
+    index = hashindex(key, sz)
     @inbounds while true
         si = slots[index]
-        isslotempty(si) && break
-        if isslotfilled(si) && isequal(key, keys[si])
-            return ifelse(direct, oftype(index, si), index)
+        si == 0 && return -1
+        if si > 0 && isequal(key, keys[si])
+            return Int(si)
         end
-
         index = (index & (sz-1)) + 1
-        iter += 1
-        iter > maxprobe && break
     end
+end
 
-    return -1
+# slot index of `key` (for delete!/pop!), or -1 if absent.
+function ht_slotindex(h::OrderedDict{K,V}, key) where {K,V}
+    slots = h.slots
+    sz = length(slots)
+    sz == 0 && return -1
+    keys = h.keys
+    index = hashindex(key, sz)
+    @inbounds while true
+        si = slots[index]
+        si == 0 && return -1
+        if si > 0 && isequal(key, keys[si])
+            return index
+        end
+        index = (index & (sz-1)) + 1
+    end
 end
 
 # get the index where a key is stored, or -pos if not present
@@ -265,46 +245,26 @@ end
 function ht_keyindex2(h::OrderedDict{K,V}, key) where {K,V}
     slots = h.slots
     sz = length(slots)
-    iter = 0
-    maxprobe = h.maxprobe
-    index = hashindex(key, sz)
+    if sz == 0
+        rehash!(h, 16)
+        slots = h.slots
+        sz = length(slots)
+    end
     keys = h.keys
+    index = hashindex(key, sz)
     avail = 0
-
     @inbounds while true
         si = slots[index]
-        if isslotempty(si)
-            avail < 0 && return avail
-            return -index
+        if si == 0
+            return avail < 0 ? avail : -index
         end
-
-        if isslotmissing(si)
+        if si < 0
             avail == 0 && (avail = -index)
         elseif key === keys[si] || isequal(key, keys[si])
-            return oftype(index, si)
-        end
-
-        index = (index & (sz-1)) + 1
-        iter += 1
-        iter > maxprobe && break
-    end
-
-    avail < 0 && return avail
-
-    # If key is not present, may need to keep searching to find slot
-    maxallowed = max(maxallowedprobe, sz>>maxprobeshift)
-    @inbounds while iter < maxallowed
-        if !isslotfilled(slots[index])
-            h.maxprobe = iter
-            return -index
+            return Int(si)
         end
         index = (index & (sz-1)) + 1
-        iter += 1
     end
-
-    rehash!(h, length(h) > 64000 ? sz*2 : sz*4)
-
-    return ht_keyindex2(h, key)
 end
 
 function _setindex!(h::OrderedDict, v, key, index)
@@ -383,25 +343,25 @@ function get!(default::Base.Callable, h::OrderedDict{K,V}, key0) where {K,V}
 end
 
 function getindex(h::OrderedDict{K,V}, key) where {K,V}
-    index = ht_keyindex(h, key, true)
+    index = ht_keyindex(h, key)
     return (index<0) ? throw(KeyError(key)) : h.vals[index]::V
 end
 
 function get(h::OrderedDict{K,V}, key, default) where {K,V}
-    index = ht_keyindex(h, key, true)
+    index = ht_keyindex(h, key)
     return (index<0) ? default : h.vals[index]::V
 end
 
 function get(default::Base.Callable, h::OrderedDict{K,V}, key) where {K,V}
-    index = ht_keyindex(h, key, true)
+    index = ht_keyindex(h, key)
     return (index<0) ? default() : h.vals[index]::V
 end
 
-haskey(h::OrderedDict, key) = (ht_keyindex(h, key, true) >= 0)
-in(key, v::Base.KeySet{K,T}) where {K,T<:OrderedDict{K}} = (ht_keyindex(v.dict, key, true) >= 0)
+haskey(h::OrderedDict, key) = (ht_keyindex(h, key) >= 0)
+in(key, v::Base.KeySet{K,T}) where {K,T<:OrderedDict{K}} = (ht_keyindex(v.dict, key) >= 0)
 
 function getkey(h::OrderedDict{K,V}, key, default) where {K,V}
-    index = ht_keyindex(h, key, true)
+    index = ht_keyindex(h, key)
     return (index<0) ? default : h.keys[index]::K
 end
 
@@ -414,24 +374,24 @@ end
 function pop!(h::OrderedDict)
     h.ndel > 0 && rehash!(h)
     key = h.keys[end]
-    index = ht_keyindex(h, key, false)
+    index = ht_slotindex(h, key)
     return key => _pop!(h, index)
 end
 
 function popfirst!(h::OrderedDict)
     h.ndel > 0 && rehash!(h)
     key = h.keys[1]
-    index = ht_keyindex(h, key, false)
+    index = ht_slotindex(h, key)
     key => _pop!(h, index)
 end
 
 function pop!(h::OrderedDict, key)
-    index = ht_keyindex(h, key, false)
+    index = ht_slotindex(h, key)
     index > 0 ? _pop!(h, index) : throw(KeyError(key))
 end
 
 function pop!(h::OrderedDict, key, default)
-    index = ht_keyindex(h, key, false)
+    index = ht_slotindex(h, key)
     index > 0 ? _pop!(h, index) : default
 end
 
@@ -446,7 +406,7 @@ function _delete!(h::OrderedDict, index)
 end
 
 function delete!(h::OrderedDict, key)
-    index = ht_keyindex(h, key, false)
+    index = ht_slotindex(h, key)
     if index > 0; _delete!(h, index); end
     return h
 end

--- a/src/ordered_set.jl
+++ b/src/ordered_set.jl
@@ -21,7 +21,7 @@ struct OrderedSet{T}  <: AbstractSet{T}
         slots = copy(d.slots)
         keys = copy(d.keys)
         vals = similar(d.vals, Nothing)
-        new{T}(OrderedDict{T,Nothing}(slots, keys, vals, d.ndel, d.maxprobe, d.dirty))
+        new{T}(OrderedDict{T,Nothing}(slots, keys, vals, d.ndel, d.dirty))
     end
 end
 

--- a/src/ordered_set.jl
+++ b/src/ordered_set.jl
@@ -21,7 +21,7 @@ struct OrderedSet{T}  <: AbstractSet{T}
         slots = copy(d.slots)
         keys = copy(d.keys)
         vals = similar(d.vals, Nothing)
-        new{T}(OrderedDict{T,Nothing}(slots, keys, vals, d.ndel, d.dirty))
+        new{T}(OrderedDict{T,Nothing}(slots, keys, vals, d.len, d.ndel, d.dirty))
     end
 end
 
@@ -53,11 +53,11 @@ copymutable(s::OrderedSet) = copy(s)
 # NOTE: manually optimized to take advantage of OrderedDict representation
 function iterate(s::OrderedSet)
     s.dict.ndel > 0 && rehash!(s.dict)
-    length(s.dict.keys) < 1 && return nothing
+    s.dict.len < 1 && return nothing
     return (s.dict.keys[1], 2)
 end
 function iterate(s::OrderedSet, i)
-    length(s.dict.keys) < i && return nothing
+    s.dict.len < i && return nothing
     return (s.dict.keys[i], i+1)
 end
 
@@ -87,7 +87,11 @@ end
 function hash(s::OrderedSet, h::UInt)
     h = hash(orderedset_seed, h)
     s.dict.ndel > 0 && rehash!(s.dict)
-    hash(s.dict.keys, h)
+    d = s.dict
+    @inbounds for i in 1:d.len
+        h = hash(d.keys[i], h)
+    end
+    return h
 end
 
 # Deprecated functionality, see
@@ -102,7 +106,7 @@ end
 function lastindex(s::OrderedSet)
     Base.depwarn("indexing is deprecated for OrderedSet, please rewrite your code to use iteration", :lastindex)
     s.dict.ndel > 0 && rehash!(s.dict)
-    return lastindex(s.dict.keys)
+    return s.dict.len
 end
 
 function nextind(::OrderedSet, i::Int)

--- a/test/test_ordered_dict.jl
+++ b/test/test_ordered_dict.jl
@@ -3,7 +3,9 @@ using OrderedCollections, Test
 @testset "OrderedDict" begin
 
     @testset "Constructors" begin
-        @test isa(@inferred(OrderedDict{Int,Float64}(zeros(Int,16), Vector{Int}(), Vector{Float64}(), 0, 0, false)), OrderedDict{Int,Float64})
+        let d0 = OrderedDict{Int,Float64}()
+            @test isa(@inferred(OrderedDict{Int,Float64}(d0.slots, d0.keys, d0.vals, 0, false)), OrderedDict{Int,Float64})
+        end
         @test isa(@inferred(OrderedDict()), OrderedDict{Any,Any})
         @test isa(@inferred(OrderedDict([(1,2.0)])), OrderedDict{Int,Float64})
         @test isa(@inferred(OrderedDict([("a",1),("b",2)])), OrderedDict{String,Int})

--- a/test/test_ordered_dict.jl
+++ b/test/test_ordered_dict.jl
@@ -4,7 +4,7 @@ using OrderedCollections, Test
 
     @testset "Constructors" begin
         let d0 = OrderedDict{Int,Float64}()
-            @test isa(@inferred(OrderedDict{Int,Float64}(d0.slots, d0.keys, d0.vals, 0, false)), OrderedDict{Int,Float64})
+            @test isa(@inferred(OrderedDict{Int,Float64}(d0.slots, d0.keys, d0.vals, 0, 0, false)), OrderedDict{Int,Float64})
         end
         @test isa(@inferred(OrderedDict()), OrderedDict{Any,Any})
         @test isa(@inferred(OrderedDict([(1,2.0)])), OrderedDict{Int,Float64})

--- a/test/test_ordered_set.jl
+++ b/test/test_ordered_set.jl
@@ -3,7 +3,7 @@ using OrderedCollections, Test
 @testset "OrderedSet" begin
 
     @testset "Constructors" begin
-        @test isa(OrderedSet{Int}(keys(OrderedDict{Int,Float64}(zeros(Int,16), Vector{Int}(), Vector{Float64}(), 0, 0, false))), OrderedSet{Int})
+        @test isa(OrderedSet{Int}(keys(OrderedDict{Int,Float64}())), OrderedSet{Int})
         @test isa(OrderedSet{Int}(keys(OrderedDict([(1,2.0)]))), OrderedSet{Int})
         @test isa(OrderedSet(), OrderedSet{Any})
         @test isa(OrderedSet([1,2,3]), OrderedSet{Int})


### PR DESCRIPTION
By moving the storage from `Vector` to `Memory` (on 1.11+)  we can save a couple pointer indirections (and a little bit of struct size). We also speed up `ht_keyindex` by splitting the `direct` parameter into 2 separate functions which removes the `if/else` from the probing loop. We also remove the `maxprobe` parameter which just seems worse for performance. The benchmarks show that this version is consistently faster for insertions, and slightly faster for lookup of existing keys.

```
  using BenchmarkTools, OrderedCollections, Printf
  build(n)=(d=OrderedDict{Int,Int}(); for i in 1:n; d[i]=i; end; d)
  hit(d,ks)=(s=0; @inbounds for k in ks; s+=d[k]; end; s)
  miss(d,ks)=(s=0; @inbounds for k in ks; s+=get(d,k,0); end; s)
  upd(d,ks)=(@inbounds for k in ks; d[k]=k+1; end)
  itr(d)=(s=0; for (k,v) in d; s+=k; s+=v; end; s)
  m(b)=minimum(b).time
  println("size      hit     miss   insert   update     iter   (ns/op)")
  for n in (8, 64, 1000, 100_000)
      d=build(n); ks=collect(1:n); mk=collect(n+1:2n)
      @printf("%7d %7.2f %7.2f %8.2f %8.2f %8.2f\n", n,
          m(@benchmark hit($d,$ks) seconds=0.4)/n,
          m(@benchmark miss($d,$mk) seconds=0.4)/n,
          m(@benchmark build($n) seconds=0.4)/n,
          m(@benchmark upd($d,$ks) seconds=0.4)/n,
          m(@benchmark itr($d) seconds=0.4)/n)
  end
  
 ```
 
  | size | op | master | PR | Δ |
  |------|--------|-------:|--------:|------:|
  | 8 | hit | 2.70 | 2.67 | ~flat |
  | 8 | insert | 17.07 | 8.35 | −51% |
  | 8 | update | 4.35 | 4.06 | −7% |
  | 64 | hit | 2.53 | 2.37 | −6% |
  | 64 | insert | 14.50 | 10.61 | −27% |
  | 64 | update | 4.12 | 3.87 | −6% |
  | 1000 | hit | 2.59 | 2.36 | −9% |
  | 1000 | insert | 11.70 | 7.60 | −35% |
  | 1000 | update | 4.57 | 4.30 | −6% |
  | 100000 | hit | 7.84 | 7.52 | −4% |
  | 100000 | insert | 21.71 | 16.28 | −25% |
  | 100000 | update | 10.92 | 10.29 | −6% |
  
  Coauthored by claude (but carefully reviewed)