### PR TITLE
filter on OrderedDict keys returns an OrderedSet

### DIFF
--- a/src/ordered_set.jl
+++ b/src/ordered_set.jl
@@ -84,6 +84,14 @@ function filter!(f::Function, s::OrderedSet)
     return s
 end
 
+function filter(f, ks::Base.KeySet{T, <:OrderedDict{T}}) where {T}
+    out = OrderedSet{T}()
+    for k in ks
+        f(k) && push!(out, k)
+    end
+    return out
+end
+
 function hash(s::OrderedSet, h::UInt)
     h = hash(orderedset_seed, h)
     s.dict.ndel > 0 && rehash!(s.dict)

--- a/test/test_ordered_dict.jl
+++ b/test/test_ordered_dict.jl
@@ -413,6 +413,21 @@ using OrderedCollections, Test
         @test filter(p->first(p) > 1, OrderedDict(1=>2, 3=>4)) isa OrderedDict
     end
 
+    @testset "Issue #147" begin
+        d = OrderedDict(5=>:a, 3=>:b, 1=>:c, 4=>:d, 2=>:e)
+        odd = filter(isodd, keys(d))
+        @test odd isa OrderedSet
+        @test collect(odd) == [5, 3, 1]
+        even = filter(iseven, keys(d))
+        @test even isa OrderedSet
+        @test collect(even) == [4, 2]
+        empt = filter(isodd, keys(OrderedDict{Int,Int}()))
+        @test empt isa OrderedSet
+        @test isempty(empt)
+        # plain Dict keys are untouched: still an unordered Set
+        @test filter(isodd, keys(Dict(1=>:a))) isa Set
+    end
+
     @testset "Issue #30" begin
         d = OrderedDict(:a=>1, :b=>2)
         d1 = OrderedDict(k=>v for (k,v) in d)


### PR DESCRIPTION
`filter(f, keys(d))` for an `OrderedDict` fell back to the generic
`AbstractSet` filter, which collects into a `Set` and drops the insertion
order:

```julia
d = OrderedDict(5=>:a, 3=>:b, 1=>:c, 4=>:d, 2=>:e)
filter(isodd, keys(d))   # Set([5, 3, 1]) — order lost
```

Add a `filter` method for the `OrderedDict` KeySet that returns an `OrderedSet`,
preserving insertion order. `OrderedSet <: AbstractSet`, so the
`filter(::AbstractSet)` return-type contract still holds. Plain `Dict` keys are
unaffected.

Fixes #147
