### PR TITLE
avoid rehashing in read-only operations (and fix some bugs)

### DIFF
--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -16,10 +16,12 @@ mutable struct OrderedDict{K,V} <: AbstractDict{K,V}
     ndel::Int
     maxprobe::Int
     dirty::Bool
+    firstlive::Int
+    lastlive::Int
 end
 
 function OrderedDict{K,V}() where {K,V}
-    OrderedDict{K,V}(zeros(Int32,16), Vector{K}(), Vector{V}(), Vector{Bool}(), 0, 0, false)
+    OrderedDict{K,V}(zeros(Int32,16), Vector{K}(), Vector{V}(), Vector{Bool}(), 0, 0, false, 1, 0)
 end
 
 function OrderedDict{K,V}(kv) where {K,V}
@@ -42,11 +44,8 @@ function OrderedDict{K,V}(ps::Pair...) where {K,V}
 end
 
 function OrderedDict{K,V}(d::OrderedDict{K,V}) where {K,V}
-    if d.ndel > 0
-        rehash!(d)
-    end
-    @assert d.ndel == 0
-    OrderedDict{K,V}(copy(d.slots), copy(d.keys), copy(d.vals), fill(true, length(d.keys)), 0, d.maxprobe, false)
+    # Copy the representation verbatim (holes included) so copying never mutates `d`.
+    OrderedDict{K,V}(copy(d.slots), copy(d.keys), copy(d.vals), copy(d.live), d.ndel, d.maxprobe, d.dirty, d.firstlive, d.lastlive)
 end
 
 OrderedDict() = OrderedDict{Any,Any}()
@@ -134,6 +133,8 @@ function rehash!(h::OrderedDict{K,V}, newsz::Integer = length(h.slots)) where {K
         resize!(h.vals, 0)
         resize!(h.live, 0)
         h.ndel = 0
+        h.firstlive = 1
+        h.lastlive = 0
         return h
     end
 
@@ -193,6 +194,9 @@ function rehash!(h::OrderedDict{K,V}, newsz::Integer = length(h.slots)) where {K
 
     h.slots = slots
     h.maxprobe = maxprobe
+    # after compaction there are no holes
+    h.firstlive = 1
+    h.lastlive = length(h.keys)
     return h
 end
 
@@ -216,6 +220,8 @@ function empty!(h::OrderedDict{K,V}) where {K,V}
     empty!(h.vals)
     empty!(h.live)
     h.ndel = 0
+    h.firstlive = 1
+    h.lastlive = 0
     h.dirty = true
     return h
 end
@@ -299,6 +305,7 @@ function _setindex!(h::OrderedDict, v, key, index)
     push!(h.live, true)
     nk = length(hk)
     @inbounds h.slots[index] = nk
+    h.lastlive = nk
     h.dirty = true
 
     sz = length(h.slots)
@@ -398,7 +405,7 @@ function _pop!(h::OrderedDict, index)
 end
 
 function _lastlive(h::OrderedDict)
-    i = length(h.keys)
+    i = h.lastlive
     @inbounds while i >= 1 && !h.live[i]
         i -= 1
     end
@@ -406,7 +413,7 @@ function _lastlive(h::OrderedDict)
 end
 function _firstlive(h::OrderedDict)
     n = length(h.keys)
-    i = 1
+    i = h.firstlive
     @inbounds while i <= n && !h.live[i]
         i += 1
     end
@@ -416,6 +423,7 @@ end
 function pop!(h::OrderedDict)
     i = _lastlive(h)
     i == 0 && throw(ArgumentError("dict must be non-empty"))
+    h.lastlive = i
     key = @inbounds h.keys[i]
     index = ht_keyindex(h, key, false)
     return key => _pop!(h, index)
@@ -424,6 +432,7 @@ end
 function popfirst!(h::OrderedDict)
     i = _firstlive(h)
     i == 0 && throw(ArgumentError("dict must be non-empty"))
+    h.firstlive = i
     key = @inbounds h.keys[i]
     index = ht_keyindex(h, key, false)
     return key => _pop!(h, index)

--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -1,5 +1,3 @@
-using Base: isbitsunion
-
 # These can be changed, to trade off better performance for space
 const global maxallowedprobe = isdefined(Base, :maxallowedprobe) ? Base.maxallowedprobe : 16
 const global maxprobeshift   = isdefined(Base, :maxprobeshift) ? Base.maxprobeshift : 6
@@ -14,13 +12,14 @@ mutable struct OrderedDict{K,V} <: AbstractDict{K,V}
     slots::Vector{Int32}
     keys::Vector{K}
     vals::Vector{V}
+    live::Vector{Bool}
     ndel::Int
     maxprobe::Int
     dirty::Bool
 end
 
 function OrderedDict{K,V}() where {K,V}
-    OrderedDict{K,V}(zeros(Int32,16), Vector{K}(), Vector{V}(), 0, 0, false)
+    OrderedDict{K,V}(zeros(Int32,16), Vector{K}(), Vector{V}(), Vector{Bool}(), 0, 0, false)
 end
 
 function OrderedDict{K,V}(kv) where {K,V}
@@ -47,7 +46,7 @@ function OrderedDict{K,V}(d::OrderedDict{K,V}) where {K,V}
         rehash!(d)
     end
     @assert d.ndel == 0
-    OrderedDict{K,V}(copy(d.slots), copy(d.keys), copy(d.vals), 0, d.maxprobe, false)
+    OrderedDict{K,V}(copy(d.slots), copy(d.keys), copy(d.vals), fill(true, length(d.keys)), 0, d.maxprobe, false)
 end
 
 OrderedDict() = OrderedDict{Any,Any}()
@@ -123,10 +122,8 @@ isslotfilled(slot_value::Integer) = slot_value > 0
 isslotmissing(slot_value::Integer) = slot_value < 0
 
 function rehash!(h::OrderedDict{K,V}, newsz::Integer = length(h.slots)) where {K,V}
-    olds = h.slots
     keys = h.keys
     vals = h.vals
-    sz = length(olds)
     newsz = _tablesz(newsz)
     h.dirty = true
     count0 = length(h)
@@ -135,6 +132,7 @@ function rehash!(h::OrderedDict{K,V}, newsz::Integer = length(h.slots)) where {K
         fill!(h.slots, 0)
         resize!(h.keys, 0)
         resize!(h.vals, 0)
+        resize!(h.live, 0)
         h.ndel = 0
         return h
     end
@@ -144,7 +142,6 @@ function rehash!(h::OrderedDict{K,V}, newsz::Integer = length(h.slots)) where {K
 
     if h.ndel > 0
         ndel0 = h.ndel
-        ptrs = !isbitstype(K) && !isbitsunion(K)
         to = 1
         # TODO: to get the best performance we need to avoid reallocating these.
         # This algorithm actually works in place, unless the dict is modified
@@ -152,43 +149,30 @@ function rehash!(h::OrderedDict{K,V}, newsz::Integer = length(h.slots)) where {K
         newkeys = similar(keys, count0)
         newvals = similar(vals, count0)
         @inbounds for from = 1:length(keys)
-            if !ptrs || isassigned(keys, from)
+            # `live` is the source of truth for which entries are deleted holes;
+            # a live entry is always assigned, so reading `keys[from]` is safe.
+            if h.live[from]
                 k = keys[from]
-                hashk = hash(k)%Int
-                isdeleted = false
-                if !ptrs
-                    iter = 0
-                    index = (hashk & (sz-1)) + 1
-                    while iter <= h.maxprobe
-                        si = olds[index]
-                        si == from && break
-                        # if we find si == 0, then the key was deleted and it's slot was reused/overwritten
-                        (si == -from || si == 0) && (isdeleted = true; break)
-                        index = (index & (sz-1)) + 1
-                        iter += 1
-                    end
-                    iter > h.maxprobe && (isdeleted = true)  # Another case where the slot was reused/overwritten
+                index0 = index = hashindex(k, newsz)
+                while slots[index] != 0
+                    index = (index & (newsz-1)) + 1
                 end
-                if !isdeleted
-                    index0 = index = (hashk & (newsz-1)) + 1
-                    while slots[index] != 0
-                        index = (index & (newsz-1)) + 1
-                    end
-                    probe = (index - index0) & (newsz-1)
-                    probe > maxprobe && (maxprobe = probe)
-                    slots[index] = to
-                    newkeys[to] = k
-                    newvals[to] = vals[from]
-                    to += 1
-                end
-                if h.ndel != ndel0
-                    # if items are removed by finalizers, retry
-                    return rehash!(h, newsz)
-                end
+                probe = (index - index0) & (newsz-1)
+                probe > maxprobe && (maxprobe = probe)
+                slots[index] = to
+                newkeys[to] = k
+                newvals[to] = vals[from]
+                to += 1
+            end
+            if h.ndel != ndel0
+                # if items are removed by finalizers, retry
+                return rehash!(h, newsz)
             end
         end
         h.keys = newkeys
         h.vals = newvals
+        resize!(h.live, length(newkeys))
+        fill!(h.live, true)
         h.ndel = 0
     else
         @inbounds for i = 1:count0
@@ -230,6 +214,7 @@ function empty!(h::OrderedDict{K,V}) where {K,V}
     fill!(h.slots, 0)
     empty!(h.keys)
     empty!(h.vals)
+    empty!(h.live)
     h.ndel = 0
     h.dirty = true
     return h
@@ -311,6 +296,7 @@ function _setindex!(h::OrderedDict, v, key, index)
     hk, hv = h.keys, h.vals
     push!(hk, key)
     push!(hv, v)
+    push!(h.live, true)
     nk = length(hk)
     @inbounds h.slots[index] = nk
     h.dirty = true
@@ -411,18 +397,36 @@ function _pop!(h::OrderedDict, index)
     return val
 end
 
+function _lastlive(h::OrderedDict)
+    i = length(h.keys)
+    @inbounds while i >= 1 && !h.live[i]
+        i -= 1
+    end
+    return i
+end
+function _firstlive(h::OrderedDict)
+    n = length(h.keys)
+    i = 1
+    @inbounds while i <= n && !h.live[i]
+        i += 1
+    end
+    return i > n ? 0 : i
+end
+
 function pop!(h::OrderedDict)
-    h.ndel > 0 && rehash!(h)
-    key = h.keys[end]
+    i = _lastlive(h)
+    i == 0 && throw(ArgumentError("dict must be non-empty"))
+    key = @inbounds h.keys[i]
     index = ht_keyindex(h, key, false)
     return key => _pop!(h, index)
 end
 
 function popfirst!(h::OrderedDict)
-    h.ndel > 0 && rehash!(h)
-    key = h.keys[1]
+    i = _firstlive(h)
+    i == 0 && throw(ArgumentError("dict must be non-empty"))
+    key = @inbounds h.keys[i]
     index = ht_keyindex(h, key, false)
-    key => _pop!(h, index)
+    return key => _pop!(h, index)
 end
 
 function pop!(h::OrderedDict, key)
@@ -438,6 +442,7 @@ end
 function _delete!(h::OrderedDict, index)
     @inbounds ki = h.slots[index]
     @inbounds h.slots[index] = -ki
+    @inbounds h.live[ki] = false
     @inbounds Base._unsetindex!(h.keys, Int(ki))
     @inbounds Base._unsetindex!(h.vals, Int(ki))
     h.ndel += 1
@@ -451,28 +456,23 @@ function delete!(h::OrderedDict, key)
     return h
 end
 
-function iterate(t::OrderedDict{K,V}) where {K,V}
-    t.ndel > 0 && rehash!(t)
-    length(t.keys) < 1 && return nothing
-    @inbounds return (Pair{K,V}(t.keys[1], t.vals[1]), 2)
-end
-function iterate(t::OrderedDict{K,V}, i) where {K,V}
-    length(t.keys) < i && return nothing
-    @inbounds return (Pair{K,V}(t.keys[i], t.vals[i]), i+1)
+function iterate(t::OrderedDict{K,V}, i::Int = 1) where {K,V}
+    n = length(t.keys)
+    @inbounds while i <= n
+        t.live[i] && return (Pair{K,V}(t.keys[i], t.vals[i]), i + 1)
+        i += 1
+    end
+    return nothing
 end
 
 # lazy reverse iteration
-function iterate(rt::Iterators.Reverse{<:OrderedDict{K,V}}) where {K,V}
+function iterate(rt::Iterators.Reverse{<:OrderedDict{K,V}}, i::Int = length(rt.itr.keys)) where {K,V}
     t = rt.itr
-    t.ndel > 0 && rehash!(t)
-    n = length(t.keys)
-    n < 1 && return nothing
-    @inbounds return (Pair{K,V}(t.keys[n], t.vals[n]), n - 1)
-end
-function iterate(rt::Iterators.Reverse{<:OrderedDict{K,V}}, i) where {K,V}
-    t = rt.itr
-    i < 1 && return nothing
-    @inbounds return (Pair{K,V}(t.keys[i], t.vals[i]), i - 1)
+    @inbounds while i >= 1
+        t.live[i] && return (Pair{K,V}(t.keys[i], t.vals[i]), i - 1)
+        i -= 1
+    end
+    return nothing
 end
 
 
@@ -500,16 +500,15 @@ merge(combine::Function, d::OrderedDict, others::AbstractDict...) = mergewith(co
 function Base.map!(f, iter::Base.ValueIterator{<:OrderedDict})
     dict = iter.dict
     vals = dict.vals
-    elements = length(vals) - dict.ndel
-    elements == 0 && return iter
-    for i in dict.slots
-        if i > 0
-            @inbounds vals[i] = f(vals[i])
-            elements -= 1
-            elements == 0 && break
-        end
+    live = dict.live
+    @inbounds for i in 1:length(vals)
+        live[i] && (vals[i] = f(vals[i]))
     end
     return iter
 end
 
-last(h::OrderedDict) = h.keys[end] => h.vals[end]
+function last(h::OrderedDict)
+    i = _lastlive(h)
+    i == 0 && throw(ArgumentError("collection must be non-empty"))
+    @inbounds return h.keys[i] => h.vals[i]
+end

--- a/src/ordered_set.jl
+++ b/src/ordered_set.jl
@@ -22,7 +22,7 @@ struct OrderedSet{T}  <: AbstractSet{T}
         keys = copy(d.keys)
         vals = similar(d.vals, Nothing)
         live = copy(d.live)
-        new{T}(OrderedDict{T,Nothing}(slots, keys, vals, live, d.ndel, d.maxprobe, d.dirty))
+        new{T}(OrderedDict{T,Nothing}(slots, keys, vals, live, d.ndel, d.maxprobe, d.dirty, d.firstlive, d.lastlive))
     end
 end
 

--- a/src/ordered_set.jl
+++ b/src/ordered_set.jl
@@ -21,7 +21,8 @@ struct OrderedSet{T}  <: AbstractSet{T}
         slots = copy(d.slots)
         keys = copy(d.keys)
         vals = similar(d.vals, Nothing)
-        new{T}(OrderedDict{T,Nothing}(slots, keys, vals, d.ndel, d.maxprobe, d.dirty))
+        live = copy(d.live)
+        new{T}(OrderedDict{T,Nothing}(slots, keys, vals, live, d.ndel, d.maxprobe, d.dirty))
     end
 end
 
@@ -50,22 +51,25 @@ empty!(s::OrderedSet{T}) where {T} = (empty!(s.dict); s)
 emptymutable(s::OrderedSet{T}, ::Type{U}=T) where {T,U} = OrderedSet{U}()
 copymutable(s::OrderedSet) = copy(s)
 
-# NOTE: manually optimized to take advantage of OrderedDict representation
-function iterate(s::OrderedSet)
-    s.dict.ndel > 0 && rehash!(s.dict)
-    length(s.dict.keys) < 1 && return nothing
-    return (s.dict.keys[1], 2)
-end
-function iterate(s::OrderedSet, i)
-    length(s.dict.keys) < i && return nothing
-    return (s.dict.keys[i], i+1)
+# NOTE: manually optimized to take advantage of OrderedDict representation.
+function iterate(s::OrderedSet, i::Int = 1)
+    d = s.dict
+    n = length(d.keys)
+    @inbounds while i <= n
+        d.live[i] && return (d.keys[i], i + 1)
+        i += 1
+    end
+    return nothing
 end
 
 # lazy reverse iteration
-function iterate(rs::Iterators.Reverse{<:OrderedSet}, i = length(rs.itr))
-    s = rs.itr
-    i < 1 && return nothing
-    return (s.dict.keys[i], i-1)
+function iterate(rs::Iterators.Reverse{<:OrderedSet}, i::Int = length(rs.itr.dict.keys))
+    d = rs.itr.dict
+    @inbounds while i >= 1
+        d.live[i] && return (d.keys[i], i - 1)
+        i -= 1
+    end
+    return nothing
 end
 
 pop!(s::OrderedSet) = pop!(s.dict)[1]
@@ -85,7 +89,11 @@ function filter!(f::Function, s::OrderedSet)
 end
 
 function hash(s::OrderedSet, h::UInt)
-    h = hash(orderedset_seed, h)
-    s.dict.ndel > 0 && rehash!(s.dict)
-    hash(s.dict.keys, h)
+    hv = hash(orderedset_seed, h)
+    d = s.dict
+    @inbounds for i in 1:length(d.keys)
+        d.live[i] || continue
+        hv = hash(d.keys[i], hv)
+    end
+    return hv
 end

--- a/test/test_ordered_dict.jl
+++ b/test/test_ordered_dict.jl
@@ -3,7 +3,7 @@ using OrderedCollections, Test
 @testset "OrderedDict" begin
 
     @testset "Constructors" begin
-        @test isa(@inferred(OrderedDict{Int,Float64}(zeros(Int,16), Vector{Int}(), Vector{Float64}(), 0, 0, false)), OrderedDict{Int,Float64})
+        @test isa(@inferred(OrderedDict{Int,Float64}(zeros(Int,16), Vector{Int}(), Vector{Float64}(), Bool[], 0, 0, false)), OrderedDict{Int,Float64})
         @test isa(@inferred(OrderedDict()), OrderedDict{Any,Any})
         @test isa(@inferred(OrderedDict([(1,2.0)])), OrderedDict{Int,Float64})
         @test isa(@inferred(OrderedDict([("a",1),("b",2)])), OrderedDict{String,Int})
@@ -550,6 +550,38 @@ using OrderedCollections, Test
             pass &= reverse(vs)[n] == v
         end
         @test pass
+    end
+
+    @testset "iteration does not mutate (pure read)" begin
+        d = OrderedDict{Int,Int}()
+        for i in 1:5; d[i] = i; end
+        delete!(d, 2); delete!(d, 4)
+        ndel_before = d.ndel
+        @test ndel_before == 2
+        for _ in d; end
+        @test d.ndel == ndel_before              # forward iteration
+        for _ in Iterators.reverse(d); end
+        @test d.ndel == ndel_before              # reverse iteration
+        # contents are still correct and skip the holes
+        @test collect(keys(d)) == [1, 3, 5]
+        @test [k for (k, v) in Iterators.reverse(d)] == [5, 3, 1]
+    end
+
+    @testset "last/pop!/popfirst! skip deleted holes" begin
+        d = OrderedDict(1 => :a, 2 => :b, 3 => :c)
+        delete!(d, 3)
+        @test last(d) == (2 => :b)
+
+        # holes at both ends; pop!/popfirst! must find the live extremes
+        d2 = OrderedDict(1=>10, 2=>20, 3=>30, 4=>40)
+        delete!(d2, 4); delete!(d2, 1)
+        @test pop!(d2) == (3 => 30)
+        @test popfirst!(d2) == (2 => 20)
+        @test isempty(d2)
+
+        @test_throws ArgumentError pop!(OrderedDict{Int,Int}())
+        @test_throws ArgumentError popfirst!(OrderedDict{Int,Int}())
+        @test_throws ArgumentError last(OrderedDict{Int,Int}())
     end
 
 end # @testset OrderedDict

--- a/test/test_ordered_dict.jl
+++ b/test/test_ordered_dict.jl
@@ -3,7 +3,7 @@ using OrderedCollections, Test
 @testset "OrderedDict" begin
 
     @testset "Constructors" begin
-        @test isa(@inferred(OrderedDict{Int,Float64}(zeros(Int,16), Vector{Int}(), Vector{Float64}(), Bool[], 0, 0, false)), OrderedDict{Int,Float64})
+        @test isa(@inferred(OrderedDict{Int,Float64}(zeros(Int,16), Vector{Int}(), Vector{Float64}(), Bool[], 0, 0, false, 1, 0)), OrderedDict{Int,Float64})
         @test isa(@inferred(OrderedDict()), OrderedDict{Any,Any})
         @test isa(@inferred(OrderedDict([(1,2.0)])), OrderedDict{Int,Float64})
         @test isa(@inferred(OrderedDict([("a",1),("b",2)])), OrderedDict{String,Int})
@@ -565,6 +565,12 @@ using OrderedCollections, Test
         # contents are still correct and skip the holes
         @test collect(keys(d)) == [1, 3, 5]
         @test [k for (k, v) in Iterators.reverse(d)] == [5, 3, 1]
+
+        # copy is a pure read of the source: it must not rehash `d`
+        c = copy(d)
+        @test d.ndel == ndel_before
+        @test c == d
+        @test collect(keys(c)) == [1, 3, 5]
     end
 
     @testset "last/pop!/popfirst! skip deleted holes" begin

--- a/test/test_ordered_set.jl
+++ b/test/test_ordered_set.jl
@@ -3,7 +3,7 @@ using OrderedCollections, Test
 @testset "OrderedSet" begin
 
     @testset "Constructors" begin
-        @test isa(OrderedSet{Int}(keys(OrderedDict{Int,Float64}(zeros(Int,16), Vector{Int}(), Vector{Float64}(), Bool[], 0, 0, false))), OrderedSet{Int})
+        @test isa(OrderedSet{Int}(keys(OrderedDict{Int,Float64}(zeros(Int,16), Vector{Int}(), Vector{Float64}(), Bool[], 0, 0, false, 1, 0))), OrderedSet{Int})
         @test isa(OrderedSet{Int}(keys(OrderedDict([(1,2.0)]))), OrderedSet{Int})
         @test isa(OrderedSet(), OrderedSet{Any})
         @test isa(OrderedSet([1,2,3]), OrderedSet{Int})

--- a/test/test_ordered_set.jl
+++ b/test/test_ordered_set.jl
@@ -3,7 +3,7 @@ using OrderedCollections, Test
 @testset "OrderedSet" begin
 
     @testset "Constructors" begin
-        @test isa(OrderedSet{Int}(keys(OrderedDict{Int,Float64}(zeros(Int,16), Vector{Int}(), Vector{Float64}(), 0, 0, false))), OrderedSet{Int})
+        @test isa(OrderedSet{Int}(keys(OrderedDict{Int,Float64}(zeros(Int,16), Vector{Int}(), Vector{Float64}(), Bool[], 0, 0, false))), OrderedSet{Int})
         @test isa(OrderedSet{Int}(keys(OrderedDict([(1,2.0)]))), OrderedSet{Int})
         @test isa(OrderedSet(), OrderedSet{Any})
         @test isa(OrderedSet([1,2,3]), OrderedSet{Int})
@@ -267,5 +267,20 @@ using OrderedCollections, Test
             pass &= reverse(ks)[n] == k
         end
         @test pass
+    end
+
+    @testset "iteration with deletions" begin
+        s = OrderedSet(1:5)
+        delete!(s, 2)
+        @test s.dict.ndel == 1
+        @test collect(Iterators.reverse(s)) == [5, 4, 3, 1]
+        @test collect(s) == [1, 3, 4, 5]
+
+        # hash is independent of how many deleted holes the backing dict carries
+        s_holes = OrderedSet(1:6)
+        delete!(s_holes, 3); delete!(s_holes, 5)
+        @test hash(s_holes) == hash(OrderedSet([1, 2, 4, 6]))
+        @test hash(s_holes) == hash(copy(s_holes))
+        @test s_holes.dict.ndel == 2 # hashing did not rehash
     end
 end # @testset OrderedSet


### PR DESCRIPTION
Before, we could encounter a `rehash!` just by iterating the dict after e.g. a `delete!`, this is for example a concurrency issue because it means it is basically not safe to use these dicts in any concurrent way when things like iteration and hashing can mutate.

This PR fixes that, as well as fixing some minor bugs and making thrown errors consistent with Base. It also removes some awkwardness w.r.t how liveness was computed depending on if the elements where stored inline or not (the `ptrs = !isbitstype(K) && !isbitsunion(K)` part)

Before, we had things like:

```julia
julia> begin # wrong result
           s = OrderedSet(1:5)
           delete!(s, 2)
           @test collect(Iterators.reverse(s)) == [5, 4, 3, 1]
       end
Test Failed at REPL[4]:4
  Expression: collect(Iterators.reverse(s)) == [5, 4, 3, 1]
   Evaluated: [4, 3, 2, 1] == [5, 4, 3, 1]	

julia> begin # bad error
           s = OrderedSet()
           pop!(s)
       end
ERROR: BoundsError: attempt to access 0-element Vector{Any} at index [0]
Stacktrace:
 [1] throw_boundserror(A::Vector{Any}, I::Tuple{Int64})
   @ Base ./essentials.jl:15

julia> begin # wrong result
            d = OrderedDict(1 => :a, 2 => :b, 3 => :c)
            delete!(d, 3)
            @test last(d) == (2 => :b)
        end
Error During Test at REPL[7]:4
  Test threw exception
  Expression: last(d) == (2 => :b)
  UndefRefError: access to undefined reference
  Stacktrace:
   [1] getindex
     @ ./essentials.jl:920 [inlined]
   [2] last(h::OrderedDict{Int64, Symbol})
     @ OrderedCollections ~/.julia/packages/OrderedCollections/MglBA/src/ordered_dict.jl:515
```

Claude Code helped with this PR. 